### PR TITLE
Add an option to allow ‘insecure’ requests to the server

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -47,11 +47,16 @@ yargs
           return additionalHeaders;
         }
       },
+      skipSsl: {
+        alias: 'K',
+        describe: 'Allows "insecure" SSL connection to the server',
+        type: 'boolean'
+      }
     },
     async argv => {
       const outputPath = path.resolve(argv.output);
       const additionalHeaders = argv.header;
-      await downloadSchema(argv.server, outputPath, additionalHeaders);
+      await downloadSchema(argv.server, outputPath, additionalHeaders, argv.skipSsl);
     }
   )
   .command(

--- a/src/cli.js
+++ b/src/cli.js
@@ -47,7 +47,7 @@ yargs
           return additionalHeaders;
         }
       },
-      skipSsl: {
+      insecure: {
         alias: 'K',
         describe: 'Allows "insecure" SSL connection to the server',
         type: 'boolean'
@@ -56,7 +56,7 @@ yargs
     async argv => {
       const outputPath = path.resolve(argv.output);
       const additionalHeaders = argv.header;
-      await downloadSchema(argv.server, outputPath, additionalHeaders, argv.skipSsl);
+      await downloadSchema(argv.server, outputPath, additionalHeaders, argv.insecure);
     }
   )
   .command(

--- a/src/downloadSchema.js
+++ b/src/downloadSchema.js
@@ -3,6 +3,7 @@
 import fetch from 'node-fetch';
 import fs from 'fs';
 import path from 'path';
+import https from 'https';
 
 import {
   buildClientSchema,
@@ -17,8 +18,9 @@ const defaultHeaders = {
   'Content-Type': 'application/json'
 };
 
-export default async function downloadSchema(url, outputPath, additionalHeaders) {
+export default async function downloadSchema(url, outputPath, additionalHeaders, skipSsl) {
   const headers = Object.assign(defaultHeaders, additionalHeaders);
+  const agent = skipSsl ? new https.Agent({ rejectUnauthorized: false }) : null;
 
   let result;
   try {
@@ -26,6 +28,7 @@ export default async function downloadSchema(url, outputPath, additionalHeaders)
       method: 'POST',
       headers: headers,
       body: JSON.stringify({ 'query': introspectionQuery }),
+      agent,
     });
 
     result = await response.json();

--- a/src/downloadSchema.js
+++ b/src/downloadSchema.js
@@ -18,9 +18,9 @@ const defaultHeaders = {
   'Content-Type': 'application/json'
 };
 
-export default async function downloadSchema(url, outputPath, additionalHeaders, skipSsl) {
+export default async function downloadSchema(url, outputPath, additionalHeaders, insecure) {
   const headers = Object.assign(defaultHeaders, additionalHeaders);
-  const agent = skipSsl ? new https.Agent({ rejectUnauthorized: false }) : null;
+  const agent = insecure ? new https.Agent({ rejectUnauthorized: false }) : null;
 
   let result;
   try {


### PR DESCRIPTION
Currently the tools is failing to download the schema if the server is
running on https with self-signed certificate. This changes adds a new
options (`skipSsl` alias `K` as in curl) that ignores invalid server
certificates.