### PR TITLE
Fix new line at the end of TypeScript code generation

### DIFF
--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -51,7 +51,7 @@ export function generateSource(context) {
   );
 
   generator.printOnNewline('/* tslint:enable */');
-  generator.printOnNewline();
+  generator.printNewline();
 
   return generator.output;
 }

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -68,8 +68,7 @@ describe('TypeScript code generation', function() {
           } | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate simple query operations including input variables`, function() {
@@ -104,8 +103,7 @@ describe('TypeScript code generation', function() {
           } | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate simple nested query operations including input variables`, function() {
@@ -146,8 +144,7 @@ describe('TypeScript code generation', function() {
           } | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate fragmented query operations`, function() {
@@ -184,8 +181,7 @@ describe('TypeScript code generation', function() {
           } > | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate query operations with inline fragments`, function() {
@@ -224,8 +220,7 @@ describe('TypeScript code generation', function() {
           height: number | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate mutation operations with complex input types`, function() {
@@ -278,8 +273,7 @@ describe('TypeScript code generation', function() {
           } | null;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
 
     it(`should generate correct list with custom fragment`, function() {
@@ -326,8 +320,7 @@ describe('TypeScript code generation', function() {
           name: string;
         }
         /* tslint:enable */
-
-      `);
+      ` + `\n`);
     });
   });
 });


### PR DESCRIPTION
It turned out that TypeScript generated files do not end with a new
line character. The issue lies in the fact that
`generator.printOnNewline()` method was used that accepts a string
parameter. If the string is `falsy` it does nothing. The fix is to use
`printNewline()` method instead.

The tests were passing because the tag helper `stripIndent` is deleting
the new line charter when the line is ‘empty’. The tests are fixed by
appending the new line character to the expected value.