### PR TITLE
Flag to define a prefix for custom scalars

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -80,11 +80,17 @@ yargs
         demand: false,
         describe: "Don't attempt to map custom scalars [temporary option]",
         default: false
+      },
+      "custom-scalars-prefix": {
+        demand: false,
+        describe: "Prefix for custom scalars. (Implies that passthrough-custom-scalars is true if set)",
+        default: '',
+        normalize: true
       }
     },
     argv => {
       const inputPaths = argv.input.map(input => path.resolve(input));
-      const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] };
+      const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] != '', customScalarsPrefix: argv["custom-scalars-prefix"] || '' };
       generate(inputPaths, argv.schema, argv.output, argv.target, options);
     },
   )

--- a/src/cli.js
+++ b/src/cli.js
@@ -90,7 +90,7 @@ yargs
     },
     argv => {
       const inputPaths = argv.input.map(input => path.resolve(input));
-      const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] != '', customScalarsPrefix: argv["custom-scalars-prefix"] || '' };
+      const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] !== '', customScalarsPrefix: argv["custom-scalars-prefix"] || '' };
       generate(inputPaths, argv.schema, argv.output, argv.target, options);
     },
   )

--- a/src/flow/types.js
+++ b/src/flow/types.js
@@ -36,7 +36,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
   if (type instanceof GraphQLList) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? type.name: GraphQLString);
+    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: GraphQLString);
   } else {
     typeName = bareTypeName || type.name;
   }

--- a/src/swift/types.js
+++ b/src/swift/types.js
@@ -38,7 +38,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, isOptional)
   if (type instanceof GraphQLList) {
     typeName = '[' + typeNameFromGraphQLType(context, type.ofType, bareTypeName) + ']';
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? type.name: GraphQLString);
+    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: GraphQLString);
   } else {
     typeName = bareTypeName || type.name;
   }

--- a/src/typescript/types.js
+++ b/src/typescript/types.js
@@ -36,7 +36,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
   if (type instanceof GraphQLList) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? type.name: GraphQLString);
+    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: GraphQLString);
   } else {
     typeName = bareTypeName || type.name;
   }

--- a/test/swift/types.js
+++ b/test/swift/types.js
@@ -75,7 +75,11 @@ describe('Swift code generation: Types', function() {
     });
 
     it('should return a passed through custom scalar type with the passthroughCustomScalars option', function() {
-      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('CustomScalarType?');
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: '' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('CustomScalarType?');
+    });
+
+    it('should return a passed through custom scalar type with a prefix with the customScalarsPrefix option', function() {
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: 'My' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('MyCustomScalarType?');
     });
   });
 });


### PR DESCRIPTION
Builds on temporary `passthrough-custom-scalars`