### PR TITLE
Use glob to expand paths if shell fails to do so

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "chai": "^3.5.0",
     "chai-subset": "^1.3.0",
     "common-tags": "^1.3.0",
-    "glob": "^7.0.5",
     "mocha": "^3.1.2"
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",
+    "glob": "^7.0.5",
     "source-map-support": "^0.4.2",
     "change-case": "^3.0.0",
     "graphql": "^0.9.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import glob from 'glob';
 import process from 'process';
 import path from 'path';
 import yargs from 'yargs';
@@ -88,7 +89,14 @@ yargs
       }
     },
     argv => {
-      const inputPaths = argv.input.map(input => path.resolve(input));
+      let { input } = argv;
+
+      // Use glob if the user's shell was unable to expand the pattern
+      if (input.length === 1 && glob.hasMagic(input[0])) {
+        input = glob.sync(input[0]);
+      }
+      const inputPaths = input.map(input => path.resolve(input));
+
       const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] };
       generate(inputPaths, argv.schema, argv.output, argv.target, options);
     },


### PR DESCRIPTION
On some environments (Windows or Mac) if `apollo-codegen` is invoked as
npm script it fails to expand the glob input pattern. The fix is to use
`glob` module and expand the paths in code.

You [this blog post](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784) for more info.

Closes #34