### PR TITLE
Add a new command to generate introspection JSON from local schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ apollo-codegen download-schema http://localhost:8080/graphql --output schema.jso
 
 You can use the `header` option to add additional HTTP headers to the request. For example, to include an authentication token, use `--header "Authorization: Bearer <token>"`.
 
+To generate a GraphQL schema introspection JSON from a local GraphQL schema:
+
+```sh
+apollo-codegen introspect-schema schema.graphql --output schema.json
+```
+
 This tool will generate Swift code by default from a set of query definitions in `.graphql` files:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ npm install -g apollo-codegen
 To download a GraphQL schema by sending an introspection query to a server:
 
 ```sh
-apollo-codegen download-schema http://localhost:8080/graphql --output schema.json
+apollo-codegen introspect-schema http://localhost:8080/graphql --output schema.json
 ```
 
 You can use the `header` option to add additional HTTP headers to the request. For example, to include an authentication token, use `--header "Authorization: Bearer <token>"`.
+
+You can use the `insecure` option to ignore any SSL errors (for example if the server is running with self-signed certificate).
+
+**Note:** The command for downloading an introspection query was named `download-schema` but it was renamed to `introspect-schema` in order to have a single command for introspecting local or remote schemas. The old name `download-schema` is still available is an alias for backward compatibility.
 
 To generate a GraphQL schema introspection JSON from a local GraphQL schema:
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,8 +22,8 @@ function handleError(error) {
 
 yargs
   .command(
-    'download-schema <server>',
-    'Download a GraphQL schema from a server',
+    ['introspect-schema <schema>', 'download-schema'],
+    'Generate an introspection JSON from a local GraphQL file or from a remote GraphQL server',
     {
       output: {
         demand: true,
@@ -55,25 +55,14 @@ yargs
       }
     },
     async argv => {
-      const outputPath = path.resolve(argv.output);
-      const additionalHeaders = argv.header;
-      await downloadSchema(argv.server, outputPath, additionalHeaders, argv.insecure);
-    }
-  )
-  .command(
-    'introspect-schema <schemaPath>',
-    'Generate an introspection JSON from a local GraphQL file',
-    {
-      output: {
-        demand: true,
-        describe: 'Output path for GraphQL introspection JSON file',
-        default: 'schema.json',
-        normalize: true,
-        coerce: path.resolve,
-      }
-    },
-    async argv => {
-      await introspectSchema(argv.schemaPath, argv.output);
+      const { schema, output, header, insecure } = argv;
+      
+      const urlRegex = /^https?:\/\//i;
+      if (urlRegex.test(schema)) {
+        await downloadSchema(schema, output, header, insecure);
+      } else {
+        await introspectSchema(schema, output);
+      } 
     }
   )
   .command(

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ import process from 'process';
 import path from 'path';
 import yargs from 'yargs';
 
-import { downloadSchema, generate } from '.';
+import { downloadSchema, introspectSchema, generate } from '.';
 import { ToolError, logError } from './errors'
 
 import 'source-map-support/register'
@@ -58,6 +58,22 @@ yargs
       const outputPath = path.resolve(argv.output);
       const additionalHeaders = argv.header;
       await downloadSchema(argv.server, outputPath, additionalHeaders, argv.insecure);
+    }
+  )
+  .command(
+    'introspect-schema <schemaPath>',
+    'Generate an introspection JSON from a local GraphQL file',
+    {
+      output: {
+        demand: true,
+        describe: 'Output path for GraphQL introspection JSON file',
+        default: 'schema.json',
+        normalize: true,
+        coerce: path.resolve,
+      }
+    },
+    async argv => {
+      await introspectSchema(argv.schemaPath, argv.output);
     }
   )
   .command(

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export downloadSchema from './downloadSchema';
+export introspectSchema from './introspectSchema';
 export generate from './generate';

--- a/src/introspectSchema.js
+++ b/src/introspectSchema.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+
+import { buildASTSchema, graphql, parse } from 'graphql';
+import { introspectionQuery } from 'graphql/utilities';
+
+import { ToolError } from './errors'
+
+export async function introspect(schemaContents) {
+  const schema = buildASTSchema(parse(schemaContents));
+  return await graphql(schema, introspectionQuery);
+}
+
+export default async function introspectSchema(schemaPath, outputPath) {
+  if (!fs.existsSync(schemaPath)) {
+    throw new ToolError(`Cannot find GraphQL schema file: ${schemaPath}`);
+  }
+
+  const schemaContents = fs.readFileSync(schemaPath).toString();
+  const result = await introspect(schemaContents);
+
+  if (result.errors) {
+    throw new ToolError(`Errors in introspection query result: ${result.errors}`);
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+}

--- a/test/introspectSchema.js
+++ b/test/introspectSchema.js
@@ -1,0 +1,16 @@
+import chai, { expect } from 'chai'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { introspect } from '../src/introspectSchema';
+
+describe('Introspecting GraphQL schema documents', () => {
+  it(`should generate valid introspection JSON file`, async () => {
+    const schemaContents = readFileSync(join(__dirname, './starwars/schema.graphql')).toString();
+    const expected = readFileSync(join(__dirname, './starwars/schema.json')).toString();
+
+    const schema = await introspect(schemaContents);
+
+    expect(JSON.stringify(schema, null, 2)).to.be.equal(expected);
+  });
+})

--- a/test/starwars/schema.graphql
+++ b/test/starwars/schema.graphql
@@ -1,0 +1,139 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+# The query type, represents all of the entry points into our object graph
+type Query {
+  hero(episode: Episode): Character
+  reviews(episode: Episode!): [Review]
+  search(text: String): [SearchResult]
+  character(id: ID!): Character
+  droid(id: ID!): Droid
+  human(id: ID!): Human
+  starship(id: ID!): Starship
+}
+# The mutation type, represents all updates we can make to our data
+type Mutation {
+  createReview(episode: Episode, review: ReviewInput!): Review
+}
+# The episodes in the Star Wars trilogy
+enum Episode {
+  # Star Wars Episode IV: A New Hope, released in 1977.
+  NEWHOPE
+  # Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  EMPIRE
+  # Star Wars Episode VI: Return of the Jedi, released in 1983.
+  JEDI
+}
+# A character from the Star Wars universe
+interface Character {
+  # The ID of the character
+  id: ID!
+  # The name of the character
+  name: String!
+  # The friends of the character, or an empty list if they have none
+  friends: [Character]
+  # The friends of the character exposed as a connection with edges
+  friendsConnection(first: Int, after: ID): FriendsConnection!
+  # The movies this character appears in
+  appearsIn: [Episode]!
+}
+# Units of height
+enum LengthUnit {
+  # The standard unit around the world
+  METER
+  # Primarily used in the United States
+  FOOT
+}
+# A humanoid creature from the Star Wars universe
+type Human implements Character {
+  # The ID of the human
+  id: ID!
+  # What this human calls themselves
+  name: String!
+  # The home planet of the human, or null if unknown
+  homePlanet: String
+  # Height in the preferred unit, default is meters
+  height(unit: LengthUnit = METER): Float
+  # Mass in kilograms, or null if unknown
+  mass: Float
+  # This human's friends, or an empty list if they have none
+  friends: [Character]
+  # The friends of the human exposed as a connection with edges
+  friendsConnection(first: Int, after: ID): FriendsConnection!
+  # The movies this human appears in
+  appearsIn: [Episode]!
+  # A list of starships this person has piloted, or an empty list if none
+  starships: [Starship]
+}
+# An autonomous mechanical character in the Star Wars universe
+type Droid implements Character {
+  # The ID of the droid
+  id: ID!
+  # What others call this droid
+  name: String!
+  # This droid's friends, or an empty list if they have none
+  friends: [Character]
+  # The friends of the droid exposed as a connection with edges
+  friendsConnection(first: Int, after: ID): FriendsConnection!
+  # The movies this droid appears in
+  appearsIn: [Episode]!
+  # This droid's primary function
+  primaryFunction: String
+}
+# A connection object for a character's friends
+type FriendsConnection {
+  # The total number of friends
+  totalCount: Int
+  # The edges for each of the character's friends.
+  edges: [FriendsEdge]
+  # A list of the friends, as a convenience when edges are not needed.
+  friends: [Character]
+  # Information for paginating this connection
+  pageInfo: PageInfo!
+}
+# An edge object for a character's friends
+type FriendsEdge {
+  # A cursor used for pagination
+  cursor: ID!
+  # The character represented by this friendship edge
+  node: Character
+}
+# Information for paginating this connection
+type PageInfo {
+  startCursor: ID
+  endCursor: ID
+  hasNextPage: Boolean!
+}
+# Represents a review for a movie
+type Review {
+  # The number of stars this review gave, 1-5
+  stars: Int!
+  # Comment about the movie
+  commentary: String
+}
+# The input object sent when someone is creating a new review
+input ReviewInput {
+  # 0-5 stars
+  stars: Int!
+  # Comment about the movie, optional
+  commentary: String
+  # Favorite color, optional
+  favorite_color: ColorInput
+}
+# The input object sent when passing in a color
+input ColorInput {
+  red: Int!
+  green: Int!
+  blue: Int!
+}
+type Starship {
+  # The ID of the starship
+  id: ID!
+  # The name of the starship
+  name: String!
+  # Length of the starship, along the longest axis
+  length(unit: LengthUnit = METER): Float
+  coordinates: [[Float!]!]
+}
+union SearchResult = Human | Droid | Starship


### PR DESCRIPTION
Introduce a new command `introspect-schema` that will generate an
introspection JSON file based on a local GraphQL schema file.

This is useful if you need to generate `schema.json` without depending
on a running server for inspection.