### PR TITLE
Added possibleTypes of fragments to IR

### DIFF
--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -310,7 +310,6 @@ export function structDeclarationForSelectionSet(
 
     if (inlineFragmentProperties && inlineFragmentProperties.length > 0) {
       inlineFragmentProperties.forEach(property => {
-        console.log("!!!", property.possibleTypes)
         structDeclarationForSelectionSet(
           generator,
           {

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -164,6 +164,7 @@ export function structDeclarationForFragment(
   {
     fragmentName,
     typeCondition,
+    possibleTypes,
     fields,
     inlineFragments,
     fragmentSpreads,
@@ -176,7 +177,7 @@ export function structDeclarationForFragment(
     structName,
     adoptedProtocols: ['GraphQLNamedFragment'],
     parentType: typeCondition,
-    possibleTypes: possibleTypesForType(generator.context, typeCondition),
+    possibleTypes,
     fields,
     fragmentSpreads,
     inlineFragments
@@ -309,12 +310,13 @@ export function structDeclarationForSelectionSet(
 
     if (inlineFragmentProperties && inlineFragmentProperties.length > 0) {
       inlineFragmentProperties.forEach(property => {
+        console.log("!!!", property.possibleTypes)
         structDeclarationForSelectionSet(
           generator,
           {
             structName: property.bareTypeName,
             parentType: property.typeCondition,
-            possibleTypes: possibleTypesForType(generator.context, property.typeCondition),
+            possibleTypes: property.possibleTypes,
             adoptedProtocols: ['GraphQLConditionalFragment'],
             fields: property.fields,
             fragmentSpreads: property.fragmentSpreads
@@ -403,14 +405,6 @@ export function structNameForProperty(property) {
 
 export function typeNameForFragmentName(fragmentName) {
   return pascalCase(fragmentName);
-}
-
-export function possibleTypesForType(context, type) {
-  if (isAbstractType(type)) {
-    return context.schema.getPossibleTypes(type);
-  } else {
-    return [type];
-  }
 }
 
 export function typeDeclarationForGraphQLType(generator, type) {

--- a/test/compilation.js
+++ b/test/compilation.js
@@ -362,7 +362,8 @@ describe('Compiling query documents', () => {
         }
       ],
       fragmentSpreads: ['MoreHeroDetails'],
-      inlineFragments: []
+      inlineFragments: [],
+      possibleTypes: ['Human', 'Droid']
     });
 
     expect(filteredIR(fragments['MoreHeroDetails'])).to.deep.equal({
@@ -381,7 +382,8 @@ describe('Compiling query documents', () => {
         }
       ],
       fragmentSpreads: [],
-      inlineFragments: []
+      inlineFragments: [],
+      possibleTypes: ['Human', 'Droid']
     });
   });
 
@@ -451,6 +453,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HeroDetails'])).to.deep.equal({
       fragmentName: 'HeroDetails',
       typeCondition: 'Character',
+      possibleTypes: ['Human', 'Droid'],
       fragmentsReferenced: [],
       fields: [
         {
@@ -507,6 +510,7 @@ describe('Compiling query documents', () => {
           inlineFragments: [
             {
               typeCondition: 'Droid',
+              possibleTypes: ['Droid'],
               fields: [
                 {
                   responseName: 'name',
@@ -523,6 +527,7 @@ describe('Compiling query documents', () => {
             },
             {
               typeCondition: 'Human',
+              possibleTypes: ['Human'],
               fields: [
                 {
                   responseName: 'name',
@@ -590,6 +595,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['DroidDetails'])).to.deep.equal({
       fragmentName: 'DroidDetails',
       typeCondition: 'Droid',
+      possibleTypes: ['Droid'],
       fragmentsReferenced: [],
       fields: [
         {
@@ -605,6 +611,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HumanDetails'])).to.deep.equal({
       fragmentName: 'HumanDetails',
       typeCondition: 'Human',
+      possibleTypes: ['Human'],
       fragmentsReferenced: [],
       fields: [
         {
@@ -699,6 +706,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HeroDetails'])).to.deep.equal({
       fragmentName: 'HeroDetails',
       typeCondition: 'Character',
+      possibleTypes: ['Human', 'Droid'],
       fragmentsReferenced: [],
       fields: [
         {
@@ -711,6 +719,7 @@ describe('Compiling query documents', () => {
       inlineFragments: [
         {
           typeCondition: 'Droid',
+          possibleTypes: ['Droid'],
           fields: [
             {
               responseName: 'name',
@@ -727,6 +736,7 @@ describe('Compiling query documents', () => {
         },
         {
           typeCondition: 'Human',
+          possibleTypes: ['Human'],
           fields: [
             {
               responseName: 'name',
@@ -775,6 +785,7 @@ describe('Compiling query documents', () => {
           inlineFragments: [
             {
               typeCondition: 'Droid',
+              possibleTypes: ['Droid'],
               fields: [
                 {
                   responseName: 'name',
@@ -820,6 +831,7 @@ describe('Compiling query documents', () => {
           inlineFragments: [
             {
               typeCondition: 'Droid',
+              possibleTypes: ['Droid'],
               fields: [
                 {
                   responseName: 'name',
@@ -867,6 +879,7 @@ describe('Compiling query documents', () => {
           inlineFragments: [
             {
               typeCondition: 'Droid',
+              possibleTypes: ['Droid'],
               fragmentSpreads: ['HeroName'],
               fields: [],
             }
@@ -933,6 +946,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['Search']).fields[0].inlineFragments).to.deep.equal([
       {
         typeCondition: 'Droid',
+        possibleTypes: ['Droid'],
         fields: [
           {
             responseName: 'name',
@@ -949,6 +963,7 @@ describe('Compiling query documents', () => {
       },
       {
         typeCondition: 'Human',
+        possibleTypes: ['Human'],
         fields: [
           {
             responseName: 'name',

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -706,6 +706,7 @@ describe('Swift code generation', function() {
         inlineFragments: [
           {
             typeCondition: schema.getType('Droid'),
+            possibleTypes: ['Droid'],
             fields: [
               {
                 responseName: 'name',
@@ -766,6 +767,7 @@ describe('Swift code generation', function() {
         inlineFragments: [
           {
             typeCondition: schema.getType('Droid'),
+            possibleTypes: ['Droid'],
             fields: [],
             fragmentSpreads: ['HeroDetails'],
           }


### PR DESCRIPTION
Fixes #65 
One remark is that it will always add the `possibleTypes` field to fragments, also when the `typeCondition` is not an abstract type. This adds some duplications in the IR representation.

