### PR TITLE
Remove duplicate props from the generated interfaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,14 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
+    "@types/lodash.uniqwith": "^4.5.1",
     "babel-runtime": "^6.20.0",
     "glob": "^7.0.5",
     "source-map-support": "^0.4.2",
     "change-case": "^3.0.0",
     "graphql": "^0.9.1",
     "inflected": "^1.1.7",
+    "lodash.uniqwith": "^4.5.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.5.3",
     "yargs": "^6.4.0"

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -16,6 +16,7 @@ import  { isTypeProperSuperTypeOf } from '../utilities/graphql';
 
 import { camelCase, pascalCase } from 'change-case';
 import Inflector from 'inflected';
+const uniqWith = require("lodash.uniqwith");
 
 import {
   join,
@@ -170,10 +171,12 @@ export function interfaceDeclarationForFragment(
     interfaceName,
     extendTypes: fragmentSpreads ? fragmentSpreads.map(f => `${pascalCase(f)}Fragment`) : null,
   }, () => {
-    const properties = propertiesFromFields(generator.context, fields)
+    const properties = uniqWith(propertiesFromFields(generator.context, fields)
     .concat(...(inlineFragments || []).map(fragment =>
       propertiesFromFields(generator.context, fragment.fields, true)
-    ));
+    )), (p1, p2) => {
+      return (p1.fieldName === p2.fieldName) && (p1.typeName || p2.typeName);
+    });
 
     propertyDeclarations(generator, properties, true);
   });


### PR DESCRIPTION
It checks that the name and the type are the same, but ignores
the rest. (This should still cover most cases.)

Fixes #74.