### PR TITLE
Make field property names Swift-y again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-codegen",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Generate API code or type annotations based on a GraphQL schema and query documents",
   "main": "./lib/index.js",
   "bin": "./lib/cli.js",

--- a/src/swift/naming.js
+++ b/src/swift/naming.js
@@ -50,7 +50,7 @@ export function propertiesFromSelectionSet(context, selectionSet) {
 
 export function propertyFromField(context, field) {
   const name = field.name || field.responseName;
-  const propertyName = escapeIdentifierIfNeeded(name);
+  const propertyName = escapeIdentifierIfNeeded(camelCase(name));
 
   const type = field.type;
   const isOptional = field.isConditional || !(type instanceof GraphQLNonNull);


### PR DESCRIPTION
This not only improves the aesthetics of the generated property names, it actually fixes a compiler crash that could occur.

Take this initializer generated by version 0.11.0, for instance:

```swift
public init(values: [Any?]) {
  Listing = values[0] as! Listing?
}
```

The problem is that the property name is the same as its type name (`Listing`), which results in a compiler crash. This could be solved be changing the generated code to use `self.Listing = ...`. However, if property names are lower-camel-cased and type names are upper-camel-cased (which is more Swift-y), this problem just goes away. Two 🐦 with one stone.