### PR TITLE
Use Jest test runner

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,12 +2,12 @@
   "presets": [
     ["env", {
       "targets": {
-        node: "current"
+        node: 4
       }
     }]
   ],
   "plugins": [
     "transform-runtime",
-    ["transform-object-rest-spread", { "useBuiltIns": true }]
+    "transform-object-rest-spread"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,13 @@
 {
-  "presets": ["full-node4"],
-  "plugins": ["transform-runtime"]
+  "presets": [
+    ["env", {
+      "targets": {
+        node: "current"
+      }
+    }]
+  ],
+  "plugins": [
+    "transform-runtime",
+    ["transform-object-rest-spread", { "useBuiltIns": true }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
       "**/test/*.js"
     ],
     "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/lib/"
+      "<rootDir>/node_modules/",
+      "<rootDir>/lib/"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.12.0",
-    "babel-preset-full-node4": "^1.0.0",
+    "babel-preset-env": "^1.4.0",
     "babel-register": "^6.16.3",
     "common-tags": "^1.3.0",
     "jest": "^19.0.2"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "babel-preset-full-node4": "^1.0.0",
     "babel-register": "^6.16.3",
     "common-tags": "^1.3.0",
+    "chai": "^3.5.0",
+    "chai-subset": "^1.3.0",
     "jest": "^19.0.2"
   },
   "dependencies": {
@@ -40,7 +42,8 @@
   },
   "jest": {
     "testMatch": [
-      "**/test/**/*.js"
+      "**/test/**/*.js",
+      "**/test/*.js"
     ],
     "testPathIgnorePatterns": [
       "/lib/"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
       "**/test/*.js"
     ],
     "testPathIgnorePatterns": [
+      "/node_modules/",
       "/lib/"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "babel-preset-full-node4": "^1.0.0",
     "babel-register": "^6.16.3",
     "common-tags": "^1.3.0",
-    "chai": "^3.5.0",
-    "chai-subset": "^1.3.0",
     "jest": "^19.0.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "node": ">=4.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.11.4",
+    "babel-cli": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-plugin-transform-runtime": "^6.12.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
-    "babel-register": "^6.16.3",
+    "babel-register": "^6.24.1",
     "common-tags": "^1.3.0",
     "jest": "^19.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "rm -rf lib && npm run compile",
-    "test": "mocha --recursive --compilers js:babel-register"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -24,10 +24,8 @@
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-full-node4": "^1.0.0",
     "babel-register": "^6.16.3",
-    "chai": "^3.5.0",
-    "chai-subset": "^1.3.0",
     "common-tags": "^1.3.0",
-    "mocha": "^3.1.2"
+    "jest": "^19.0.2"
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",
@@ -39,5 +37,13 @@
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.5.3",
     "yargs": "^7.0.1"
+  },
+  "jest": {
+    "testMatch": [
+      "**/test/**/*.js"
+    ],
+    "testPathIgnorePatterns": [
+      "/lib/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-jest": "^19.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export downloadSchema from './downloadSchema';
-export introspectSchema from './introspectSchema';
-export generate from './generate';
+export { default as downloadSchema } from './downloadSchema';
+export { default as introspectSchema } from './introspectSchema';
+export { default as generate } from './generate';

--- a/test/__snapshots__/compilation.js.snap
+++ b/test/__snapshots__/compilation.js.snap
@@ -210,6 +210,15 @@ Object {
 }
 `;
 
+exports[`Compiling query documents should include the source of operations with __typename added for abstract types 1`] = `
+"query HeroName {
+  hero {
+    __typename
+    name
+  }
+}"
+`;
+
 exports[`Compiling query documents should include type conditions for inline fragments in fragments 1`] = `
 Object {
   "fields": Array [

--- a/test/__snapshots__/compilation.js.snap
+++ b/test/__snapshots__/compilation.js.snap
@@ -1,0 +1,731 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Compiling query documents should include fragment spreads from subselections 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The movies this character appears in",
+          "fieldName": "appearsIn",
+          "responseName": "appearsIn",
+          "type": "[Episode]!",
+        },
+        Object {
+          "description": "The ID of the character",
+          "fieldName": "id",
+          "responseName": "id",
+          "type": "ID!",
+        },
+        Object {
+          "description": "The friends of the character, or an empty list if they have none",
+          "fieldName": "friends",
+          "fields": Array [
+            Object {
+              "description": "The ID of the character",
+              "fieldName": "id",
+              "responseName": "id",
+              "type": "ID!",
+            },
+          ],
+          "fragmentSpreads": Array [
+            "HeroDetails",
+          ],
+          "inlineFragments": Array [],
+          "responseName": "friends",
+          "type": "[Character]",
+        },
+      ],
+      "fragmentSpreads": Array [
+        "HeroDetails",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "HeroDetails",
+  ],
+  "operationName": "HeroAndFriends",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include fragment spreads from subselections 2`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "The name of the character",
+      "fieldName": "name",
+      "responseName": "name",
+      "type": "String!",
+    },
+    Object {
+      "description": "The ID of the character",
+      "fieldName": "id",
+      "responseName": "id",
+      "type": "ID!",
+    },
+  ],
+  "fragmentName": "HeroDetails",
+  "fragmentSpreads": Array [],
+  "fragmentsReferenced": Array [],
+  "inlineFragments": Array [],
+  "possibleTypes": Array [
+    "Human",
+    "Droid",
+  ],
+  "typeCondition": "Character",
+}
+`;
+
+exports[`Compiling query documents should include fragment spreads with type conditions 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+      ],
+      "fragmentSpreads": Array [
+        "DroidDetails",
+        "HumanDetails",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "DroidDetails",
+    "HumanDetails",
+  ],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include fragment spreads with type conditions 2`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "This droid's primary function",
+      "fieldName": "primaryFunction",
+      "responseName": "primaryFunction",
+      "type": "String",
+    },
+  ],
+  "fragmentName": "DroidDetails",
+  "fragmentSpreads": Array [],
+  "fragmentsReferenced": Array [],
+  "inlineFragments": Array [],
+  "possibleTypes": Array [
+    "Droid",
+  ],
+  "typeCondition": "Droid",
+}
+`;
+
+exports[`Compiling query documents should include fragment spreads with type conditions 3`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "Height in the preferred unit, default is meters",
+      "fieldName": "height",
+      "responseName": "height",
+      "type": "Float",
+    },
+  ],
+  "fragmentName": "HumanDetails",
+  "fragmentSpreads": Array [],
+  "fragmentsReferenced": Array [],
+  "inlineFragments": Array [],
+  "possibleTypes": Array [
+    "Human",
+  ],
+  "typeCondition": "Human",
+}
+`;
+
+exports[`Compiling query documents should include isOptional if a field has skip or include directives 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "isConditional": true,
+          "responseName": "name",
+          "type": "String!",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "HeroNameConditionalInclusion",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include isOptional if a field has skip or include directives 2`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "isConditional": true,
+          "responseName": "name",
+          "type": "String!",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "HeroNameConditionalExclusion",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include type conditions for inline fragments in fragments 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [],
+      "fragmentSpreads": Array [
+        "HeroDetails",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "HeroDetails",
+  ],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include type conditions for inline fragments in fragments 2`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "The name of the character",
+      "fieldName": "name",
+      "responseName": "name",
+      "type": "String!",
+    },
+  ],
+  "fragmentName": "HeroDetails",
+  "fragmentSpreads": Array [],
+  "fragmentsReferenced": Array [],
+  "inlineFragments": Array [
+    Object {
+      "fields": Array [
+        Object {
+          "description": "What others call this droid",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+        Object {
+          "description": "This droid's primary function",
+          "fieldName": "primaryFunction",
+          "responseName": "primaryFunction",
+          "type": "String",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "possibleTypes": Array [
+        "Droid",
+      ],
+      "typeCondition": "Droid",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "What this human calls themselves",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+        Object {
+          "description": "Height in the preferred unit, default is meters",
+          "fieldName": "height",
+          "responseName": "height",
+          "type": "Float",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "possibleTypes": Array [
+        "Human",
+      ],
+      "typeCondition": "Human",
+    },
+  ],
+  "possibleTypes": Array [
+    "Human",
+    "Droid",
+  ],
+  "typeCondition": "Character",
+}
+`;
+
+exports[`Compiling query documents should include type conditions for inline fragments on a union type 1`] = `
+Array [
+  Object {
+    "fields": Array [
+      Object {
+        "description": "What others call this droid",
+        "fieldName": "name",
+        "responseName": "name",
+        "type": "String!",
+      },
+      Object {
+        "description": "This droid's primary function",
+        "fieldName": "primaryFunction",
+        "responseName": "primaryFunction",
+        "type": "String",
+      },
+    ],
+    "fragmentSpreads": Array [],
+    "possibleTypes": Array [
+      "Droid",
+    ],
+    "typeCondition": "Droid",
+  },
+  Object {
+    "fields": Array [
+      Object {
+        "description": "What this human calls themselves",
+        "fieldName": "name",
+        "responseName": "name",
+        "type": "String!",
+      },
+      Object {
+        "description": "Height in the preferred unit, default is meters",
+        "fieldName": "height",
+        "responseName": "height",
+        "type": "Float",
+      },
+    ],
+    "fragmentSpreads": Array [],
+    "possibleTypes": Array [
+      "Human",
+    ],
+    "typeCondition": "Human",
+  },
+]
+`;
+
+exports[`Compiling query documents should include type conditions with merged fields for inline fragments 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [
+        Object {
+          "fields": Array [
+            Object {
+              "description": "What others call this droid",
+              "fieldName": "name",
+              "responseName": "name",
+              "type": "String!",
+            },
+            Object {
+              "description": "This droid's primary function",
+              "fieldName": "primaryFunction",
+              "responseName": "primaryFunction",
+              "type": "String",
+            },
+          ],
+          "fragmentSpreads": Array [],
+          "possibleTypes": Array [
+            "Droid",
+          ],
+          "typeCondition": "Droid",
+        },
+        Object {
+          "fields": Array [
+            Object {
+              "description": "What this human calls themselves",
+              "fieldName": "name",
+              "responseName": "name",
+              "type": "String!",
+            },
+            Object {
+              "description": "Height in the preferred unit, default is meters",
+              "fieldName": "height",
+              "responseName": "height",
+              "type": "Float",
+            },
+          ],
+          "fragmentSpreads": Array [],
+          "possibleTypes": Array [
+            "Human",
+          ],
+          "typeCondition": "Human",
+        },
+      ],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should include variables defined in operations 1`] = `
+Array [
+  Object {
+    "name": "episode",
+    "type": "Episode",
+  },
+]
+`;
+
+exports[`Compiling query documents should include variables defined in operations 2`] = `
+Array [
+  Object {
+    "name": "text",
+    "type": "String!",
+  },
+]
+`;
+
+exports[`Compiling query documents should include variables defined in operations 3`] = `
+Array [
+  Object {
+    "name": "episode",
+    "type": "Episode!",
+  },
+  Object {
+    "name": "review",
+    "type": "ReviewInput!",
+  },
+]
+`;
+
+exports[`Compiling query documents should inherit type condition when nesting a fragment spread in an inline fragment with a more specific type condition 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [
+        Object {
+          "fields": Array [],
+          "fragmentSpreads": Array [
+            "HeroName",
+          ],
+          "possibleTypes": Array [
+            "Droid",
+          ],
+          "typeCondition": "Droid",
+        },
+      ],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "HeroName",
+  ],
+  "operationName": "HeroName",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should inherit type condition when nesting an inline fragment in an inline fragment with a more specific type condition 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [
+        Object {
+          "fields": Array [
+            Object {
+              "description": "What others call this droid",
+              "fieldName": "name",
+              "responseName": "name",
+              "type": "String!",
+            },
+          ],
+          "fragmentSpreads": Array [],
+          "possibleTypes": Array [
+            "Droid",
+          ],
+          "typeCondition": "Droid",
+        },
+      ],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "HeroName",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should not include type conditions for fragment spreads with type conditions that match the parent type 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+      ],
+      "fragmentSpreads": Array [
+        "HeroDetails",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "HeroDetails",
+  ],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should not inherit type condition when nesting a fragment spread in an inline fragment with a less specific type condition 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [],
+      "fragmentSpreads": Array [
+        "DroidName",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "DroidName",
+  ],
+  "operationName": "HeroName",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should not inherit type condition when nesting an inline fragment in an inline fragment with a less specific type condition 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [
+        Object {
+          "fields": Array [
+            Object {
+              "description": "What others call this droid",
+              "fieldName": "name",
+              "responseName": "name",
+              "type": "String!",
+            },
+          ],
+          "fragmentSpreads": Array [],
+          "possibleTypes": Array [
+            "Droid",
+          ],
+          "typeCondition": "Droid",
+        },
+      ],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "HeroName",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should recursively flatten inline fragments with type conditions that match the parent type 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The ID of the character",
+          "fieldName": "id",
+          "responseName": "id",
+          "type": "ID!",
+        },
+        Object {
+          "description": "The name of the character",
+          "fieldName": "name",
+          "responseName": "name",
+          "type": "String!",
+        },
+        Object {
+          "description": "The movies this character appears in",
+          "fieldName": "appearsIn",
+          "responseName": "appearsIn",
+          "type": "[Episode]!",
+        },
+      ],
+      "fragmentSpreads": Array [],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should recursively include fragment spreads with type conditions that match the parent type 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "fieldName": "hero",
+      "fields": Array [
+        Object {
+          "description": "The ID of the character",
+          "fieldName": "id",
+          "responseName": "id",
+          "type": "ID!",
+        },
+      ],
+      "fragmentSpreads": Array [
+        "HeroDetails",
+        "MoreHeroDetails",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "hero",
+      "type": "Character",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "HeroDetails",
+    "MoreHeroDetails",
+  ],
+  "operationName": "Hero",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
+exports[`Compiling query documents should recursively include fragment spreads with type conditions that match the parent type 2`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "The ID of the character",
+      "fieldName": "id",
+      "responseName": "id",
+      "type": "ID!",
+    },
+    Object {
+      "description": "The name of the character",
+      "fieldName": "name",
+      "responseName": "name",
+      "type": "String!",
+    },
+  ],
+  "fragmentName": "HeroDetails",
+  "fragmentSpreads": Array [
+    "MoreHeroDetails",
+  ],
+  "fragmentsReferenced": Array [
+    "MoreHeroDetails",
+  ],
+  "inlineFragments": Array [],
+  "possibleTypes": Array [
+    "Human",
+    "Droid",
+  ],
+  "typeCondition": "Character",
+}
+`;
+
+exports[`Compiling query documents should recursively include fragment spreads with type conditions that match the parent type 3`] = `
+Object {
+  "fields": Array [
+    Object {
+      "description": "The movies this character appears in",
+      "fieldName": "appearsIn",
+      "responseName": "appearsIn",
+      "type": "[Episode]!",
+    },
+    Object {
+      "description": "The ID of the character",
+      "fieldName": "id",
+      "responseName": "id",
+      "type": "ID!",
+    },
+  ],
+  "fragmentName": "MoreHeroDetails",
+  "fragmentSpreads": Array [],
+  "fragmentsReferenced": Array [],
+  "inlineFragments": Array [],
+  "possibleTypes": Array [
+    "Human",
+    "Droid",
+  ],
+  "typeCondition": "Character",
+}
+`;

--- a/test/compilation.js
+++ b/test/compilation.js
@@ -17,7 +17,7 @@ import { serializeAST } from '../src/serializeToJSON'
 const schema = loadSchema(require.resolve('./starwars/schema.json'));
 
 describe('Compiling query documents', () => {
-  it(`should include variables defined in operations`, () => {
+  test(`should include variables defined in operations`, () => {
     const document = parse(`
       query HeroName($episode: Episode) {
         hero(episode: $episode) {
@@ -48,7 +48,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['CreateReviewForEpisode']).variables).toMatchSnapshot();
   });
 
-  it(`should keep track of enums and input object types used in variables`, () => {
+  test(`should keep track of enums and input object types used in variables`, () => {
     const document = parse(`
       query HeroName($episode: Episode) {
         hero(episode: $episode) {
@@ -77,7 +77,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(typesUsed)).toEqual(['Episode', 'ReviewInput', 'ColorInput']);
   });
 
-  it(`should keep track of enums used in fields`, () => {
+  test(`should keep track of enums used in fields`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -96,7 +96,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(typesUsed)).toEqual(['Episode']);
   });
 
-  it(`should keep track of types used in fields of input objects`, () => {
+  test(`should keep track of types used in fields of input objects`, () => {
     const bookstore_schema = loadSchema(require.resolve('./bookstore/schema.json'));
     const document = parse(`
       query ListBooks {
@@ -129,7 +129,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(typesUsed)).toContain('WrittenByInput');
   });
 
-  it(`should include the original field name for an aliased field`, () => {
+  test(`should include the original field name for an aliased field`, () => {
     const document = parse(`
       query HeroName {
         r2: hero {
@@ -146,7 +146,7 @@ describe('Compiling query documents', () => {
     expect(operations['HeroName'].fields[0].fieldName).toBe("hero");
   });
 
-  it(`should include field arguments`, () => {
+  test(`should include field arguments`, () => {
     const document = parse(`
       query HeroName {
         hero(episode: EMPIRE) {
@@ -161,7 +161,7 @@ describe('Compiling query documents', () => {
       .toEqual([{ name: "episode", value: "EMPIRE" }]);
   });
 
-  it(`should include isOptional if a field has skip or include directives`, () => {
+  test(`should include isOptional if a field has skip or include directives`, () => {
     const document = parse(`
       query HeroNameConditionalInclusion {
         hero {
@@ -182,7 +182,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroNameConditionalExclusion'])).toMatchSnapshot();
   });
 
-  it(`should recursively flatten inline fragments with type conditions that match the parent type`, () => {
+  test(`should recursively flatten inline fragments with type conditions that match the parent type`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -204,7 +204,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
-  it(`should recursively include fragment spreads with type conditions that match the parent type`, () => {
+  test(`should recursively include fragment spreads with type conditions that match the parent type`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -232,7 +232,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['MoreHeroDetails'])).toMatchSnapshot();
   });
 
-  it(`should include fragment spreads from subselections`, () => {
+  test(`should include fragment spreads from subselections`, () => {
     const document = parse(`
       query HeroAndFriends {
         hero {
@@ -258,7 +258,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HeroDetails'])).toMatchSnapshot();
   });
 
-  it(`should include type conditions with merged fields for inline fragments`, () => {
+  test(`should include type conditions with merged fields for inline fragments`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -278,7 +278,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
-  it(`should include fragment spreads with type conditions`, () => {
+  test(`should include fragment spreads with type conditions`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -304,7 +304,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HumanDetails'])).toMatchSnapshot();
   });
 
-  it(`should not include type conditions for fragment spreads with type conditions that match the parent type`, () => {
+  test(`should not include type conditions for fragment spreads with type conditions that match the parent type`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -323,7 +323,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
-  it(`should include type conditions for inline fragments in fragments`, () => {
+  test(`should include type conditions for inline fragments in fragments`, () => {
     const document = parse(`
       query Hero {
         hero {
@@ -348,7 +348,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(fragments['HeroDetails'])).toMatchSnapshot();
   });
 
-  it(`should inherit type condition when nesting an inline fragment in an inline fragment with a more specific type condition`, () => {
+  test(`should inherit type condition when nesting an inline fragment in an inline fragment with a more specific type condition`, () => {
     const document = parse(`
       query HeroName {
         hero {
@@ -366,7 +366,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
-  it(`should not inherit type condition when nesting an inline fragment in an inline fragment with a less specific type condition`, () => {
+  test(`should not inherit type condition when nesting an inline fragment in an inline fragment with a less specific type condition`, () => {
     const document = parse(`
       query HeroName {
         hero {
@@ -384,7 +384,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
-  it(`should inherit type condition when nesting a fragment spread in an inline fragment with a more specific type condition`, () => {
+  test(`should inherit type condition when nesting a fragment spread in an inline fragment with a more specific type condition`, () => {
     const document = parse(`
       query HeroName {
         hero {
@@ -404,7 +404,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
-  it(`should not inherit type condition when nesting a fragment spread in an inline fragment with a less specific type condition`, () => {
+  test(`should not inherit type condition when nesting a fragment spread in an inline fragment with a less specific type condition`, () => {
     const document = parse(`
       query HeroName {
         hero {
@@ -423,7 +423,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
-  it(`should include type conditions for inline fragments on a union type`, () => {
+  test(`should include type conditions for inline fragments on a union type`, () => {
     const document = parse(`
       query Search {
         search(text: "an") {
@@ -445,7 +445,7 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['Search']).fields[0].inlineFragments).toMatchSnapshot();
   });
 
-  it(`should keep track of fragments referenced in a subselection`, () => {
+  test(`should keep track of fragments referenced in a subselection`, () => {
     const document = parse(`
       query HeroAndFriends {
         hero {
@@ -466,7 +466,7 @@ describe('Compiling query documents', () => {
     expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails']);
   });
 
-  it(`should keep track of fragments referenced in a fragment within a subselection`, () => {
+  test(`should keep track of fragments referenced in a fragment within a subselection`, () => {
     const document = parse(`
       query HeroAndFriends {
         hero {
@@ -490,7 +490,7 @@ describe('Compiling query documents', () => {
     expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails', 'HeroName']);
   });
 
-  it(`should keep track of fragments referenced in a subselection nested in an inline fragment`, () => {
+  test(`should keep track of fragments referenced in a subselection nested in an inline fragment`, () => {
     const document = parse(`
       query HeroAndFriends {
         hero {
@@ -513,7 +513,7 @@ describe('Compiling query documents', () => {
     expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails']);
   });
 
-  it(`should include the source of operations with __typename added for abstract types`, () => {
+  test(`should include the source of operations with __typename added for abstract types`, () => {
     const source = stripIndent`
       query HeroName {
         hero {
@@ -525,17 +525,10 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroName'].source).toBe(stripIndent`
-      query HeroName {
-        hero {
-          __typename
-          name
-        }
-      }
-    `);
+    expect(operations['HeroName'].source).toMatchSnapshot();
   });
 
-  it(`should include the source of fragments with __typename added for abstract types`, () => {
+  test(`should include the source of fragments with __typename added for abstract types`, () => {
     const source = stripIndent`
       fragment HeroDetails on Character {
         name
@@ -553,7 +546,7 @@ describe('Compiling query documents', () => {
     `);
   });
 
-  it(`should include the operationType for a query`, () => {
+  test(`should include the operationType for a query`, () => {
     const source = stripIndent`
       query HeroName {
         hero {
@@ -568,7 +561,7 @@ describe('Compiling query documents', () => {
     expect(operations['HeroName'].operationType).toBe('query');
   });
 
-  it(`should include the operationType for a mutation`, () => {
+  test(`should include the operationType for a mutation`, () => {
     const source = stripIndent`
       mutation CreateReview {
         createReview {

--- a/test/compilation.js
+++ b/test/compilation.js
@@ -1,7 +1,3 @@
-import chai, { expect } from 'chai'
-import chaiSubset from 'chai-subset'
-chai.use(chaiSubset);
-
 import { stripIndent } from 'common-tags'
 
 import {
@@ -47,24 +43,9 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroName']).variables).to.deep.equal(
-      [
-        { name: 'episode', type: 'Episode' }
-      ]
-    );
-
-    expect(filteredIR(operations['Search']).variables).to.deep.equal(
-      [
-        { name: 'text', type: 'String!' }
-      ]
-    );
-
-    expect(filteredIR(operations['CreateReviewForEpisode']).variables).to.deep.equal(
-      [
-        { name: 'episode', type: 'Episode!' },
-        { name: 'review', type: 'ReviewInput!' }
-      ]
-    );
+    expect(filteredIR(operations['HeroName']).variables).toMatchSnapshot();
+    expect(filteredIR(operations['Search']).variables).toMatchSnapshot();
+    expect(filteredIR(operations['CreateReviewForEpisode']).variables).toMatchSnapshot();
   });
 
   it(`should keep track of enums and input object types used in variables`, () => {
@@ -93,7 +74,7 @@ describe('Compiling query documents', () => {
 
     const { typesUsed } = compileToIR(schema, document);
 
-    expect(filteredIR(typesUsed)).to.deep.equal(['Episode', 'ReviewInput', 'ColorInput']);
+    expect(filteredIR(typesUsed)).toEqual(['Episode', 'ReviewInput', 'ColorInput']);
   });
 
   it(`should keep track of enums used in fields`, () => {
@@ -112,7 +93,7 @@ describe('Compiling query documents', () => {
 
     const { typesUsed } = compileToIR(schema, document);
 
-    expect(filteredIR(typesUsed)).to.deep.equal(['Episode']);
+    expect(filteredIR(typesUsed)).toEqual(['Episode']);
   });
 
   it(`should keep track of types used in fields of input objects`, () => {
@@ -144,8 +125,8 @@ describe('Compiling query documents', () => {
     `)
 
     const { typesUsed } = compileToIR(bookstore_schema, document);
-    expect(filteredIR(typesUsed)).to.deep.include('IdInput');
-    expect(filteredIR(typesUsed)).to.deep.include('WrittenByInput');
+    expect(filteredIR(typesUsed)).toContain('IdInput');
+    expect(filteredIR(typesUsed)).toContain('WrittenByInput');
   });
 
   it(`should include the original field name for an aliased field`, () => {
@@ -162,7 +143,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroName'].fields[0].fieldName).to.equal("hero");
+    expect(operations['HeroName'].fields[0].fieldName).toBe("hero");
   });
 
   it(`should include field arguments`, () => {
@@ -177,7 +158,7 @@ describe('Compiling query documents', () => {
     const { operations } = compileToIR(schema, document);
 
     expect(operations['HeroName'].fields[0].args)
-      .to.deep.equal([{ name: "episode", value: "EMPIRE" }]);
+      .toEqual([{ name: "episode", value: "EMPIRE" }]);
   });
 
   it(`should include isOptional if a field has skip or include directives`, () => {
@@ -197,53 +178,8 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroNameConditionalInclusion'])).to.deep.equal({
-      operationName: 'HeroNameConditionalInclusion',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!',
-              isConditional: true
-            },
-          ],
-          fragmentSpreads: [],
-          inlineFragments: []
-        }
-      ]
-    });
-
-    expect(filteredIR(operations['HeroNameConditionalExclusion'])).to.deep.equal({
-      operationName: 'HeroNameConditionalExclusion',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!',
-              isConditional: true
-            },
-          ],
-          fragmentSpreads: [],
-          inlineFragments: []
-        }
-      ]
-    });
+    expect(filteredIR(operations['HeroNameConditionalInclusion'])).toMatchSnapshot();
+    expect(filteredIR(operations['HeroNameConditionalExclusion'])).toMatchSnapshot();
   });
 
   it(`should recursively flatten inline fragments with type conditions that match the parent type`, () => {
@@ -265,38 +201,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            {
-              responseName: 'id',
-              fieldName: 'id',
-              type: 'ID!'
-            },
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            },
-            {
-              responseName: 'appearsIn',
-              fieldName: 'appearsIn',
-              type: '[Episode]!'
-            }
-          ],
-          fragmentSpreads: [],
-          inlineFragments: []
-        }
-      ]
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
   it(`should recursively include fragment spreads with type conditions that match the parent type`, () => {
@@ -322,69 +227,9 @@ describe('Compiling query documents', () => {
 
     const { operations, fragments } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['HeroDetails', 'MoreHeroDetails'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            {
-              responseName: 'id',
-              fieldName: 'id',
-              type: 'ID!'
-            }
-          ],
-          fragmentSpreads: ['HeroDetails', 'MoreHeroDetails'],
-          inlineFragments: [],
-        }
-      ],
-    });
-
-    expect(filteredIR(fragments['HeroDetails'])).to.deep.equal({
-      fragmentName: 'HeroDetails',
-      typeCondition: 'Character',
-      fragmentsReferenced: ['MoreHeroDetails'],
-      fields: [
-        {
-          responseName: 'id',
-          fieldName: 'id',
-          type: 'ID!'
-        },
-        {
-          responseName: 'name',
-          fieldName: 'name',
-          type: 'String!'
-        }
-      ],
-      fragmentSpreads: ['MoreHeroDetails'],
-      inlineFragments: [],
-      possibleTypes: ['Human', 'Droid']
-    });
-
-    expect(filteredIR(fragments['MoreHeroDetails'])).to.deep.equal({
-      fragmentName: 'MoreHeroDetails',
-      typeCondition: 'Character',
-      fragmentsReferenced: [],
-      fields: [
-        { responseName: 'appearsIn',
-          fieldName: 'appearsIn',
-          type: '[Episode]!'
-        },
-        {
-          responseName: 'id',
-          fieldName: 'id',
-          type: 'ID!'
-        }
-      ],
-      fragmentSpreads: [],
-      inlineFragments: [],
-      possibleTypes: ['Human', 'Droid']
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
+    expect(filteredIR(fragments['HeroDetails'])).toMatchSnapshot();
+    expect(filteredIR(fragments['MoreHeroDetails'])).toMatchSnapshot();
   });
 
   it(`should include fragment spreads from subselections`, () => {
@@ -409,67 +254,8 @@ describe('Compiling query documents', () => {
 
     const { operations, fragments } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroAndFriends'])).to.deep.equal({
-      operationName: 'HeroAndFriends',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['HeroDetails'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            { responseName: 'appearsIn',
-              fieldName: 'appearsIn',
-              type: '[Episode]!'
-            },
-            {
-              responseName: 'id',
-              fieldName: 'id',
-              type: 'ID!'
-            },
-            {
-              responseName: 'friends',
-              fieldName: 'friends',
-              type: '[Character]',
-              fields: [
-                {
-                  responseName: 'id',
-                  fieldName: 'id',
-                  type: 'ID!'
-                }
-              ],
-              fragmentSpreads: ['HeroDetails'],
-              inlineFragments: []
-            }
-          ],
-          fragmentSpreads: ['HeroDetails'],
-          inlineFragments: []
-        }
-      ]
-    });
-
-    expect(filteredIR(fragments['HeroDetails'])).to.deep.equal({
-      fragmentName: 'HeroDetails',
-      typeCondition: 'Character',
-      possibleTypes: ['Human', 'Droid'],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'name',
-          fieldName: 'name',
-          type: 'String!'
-        },
-        {
-          responseName: 'id',
-          fieldName: 'id',
-          type: 'ID!'
-        }
-      ],
-      fragmentSpreads: [],
-      inlineFragments: []
-    });
+    expect(filteredIR(operations['HeroAndFriends'])).toMatchSnapshot();
+    expect(filteredIR(fragments['HeroDetails'])).toMatchSnapshot();
   });
 
   it(`should include type conditions with merged fields for inline fragments`, () => {
@@ -489,63 +275,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            }
-          ],
-          fragmentSpreads: [],
-          inlineFragments: [
-            {
-              typeCondition: 'Droid',
-              possibleTypes: ['Droid'],
-              fields: [
-                {
-                  responseName: 'name',
-                  fieldName: 'name',
-                  type: 'String!'
-                },
-                {
-                  responseName: 'primaryFunction',
-                  fieldName: 'primaryFunction',
-                  type: 'String'
-                },
-              ],
-              fragmentSpreads: []
-            },
-            {
-              typeCondition: 'Human',
-              possibleTypes: ['Human'],
-              fields: [
-                {
-                  responseName: 'name',
-                  fieldName: 'name',
-                  type: 'String!'
-                },
-                {
-                  responseName: 'height',
-                  fieldName: 'height',
-                  type: 'Float'
-                },
-              ],
-              fragmentSpreads: []
-            }
-          ]
-        }
-      ]
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
   it(`should include fragment spreads with type conditions`, () => {
@@ -569,60 +299,9 @@ describe('Compiling query documents', () => {
 
     const { operations, fragments } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['DroidDetails', 'HumanDetails'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fragmentSpreads: ['DroidDetails', 'HumanDetails'],
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            }
-          ],
-          inlineFragments: []
-        }
-      ]
-    });
-
-    expect(filteredIR(fragments['DroidDetails'])).to.deep.equal({
-      fragmentName: 'DroidDetails',
-      typeCondition: 'Droid',
-      possibleTypes: ['Droid'],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'primaryFunction',
-          fieldName: 'primaryFunction',
-          type: 'String'
-        }
-      ],
-      fragmentSpreads: [],
-      inlineFragments: []
-    });
-
-    expect(filteredIR(fragments['HumanDetails'])).to.deep.equal({
-      fragmentName: 'HumanDetails',
-      typeCondition: 'Human',
-      possibleTypes: ['Human'],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'height',
-          fieldName: 'height',
-          type: 'Float'
-        }
-      ],
-      fragmentSpreads: [],
-      inlineFragments: []
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
+    expect(filteredIR(fragments['DroidDetails'])).toMatchSnapshot();
+    expect(filteredIR(fragments['HumanDetails'])).toMatchSnapshot();
   });
 
   it(`should not include type conditions for fragment spreads with type conditions that match the parent type`, () => {
@@ -641,28 +320,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['HeroDetails'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fragmentSpreads: ['HeroDetails'],
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            }
-          ],
-          inlineFragments: []
-        }
-      ],
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
   });
 
   it(`should include type conditions for inline fragments in fragments`, () => {
@@ -686,73 +344,8 @@ describe('Compiling query documents', () => {
 
     const { operations, fragments } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Hero'])).to.deep.equal({
-      operationName: 'Hero',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['HeroDetails'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [],
-          fragmentSpreads: ['HeroDetails'],
-          inlineFragments: []
-        }
-      ]
-    });
-
-    expect(filteredIR(fragments['HeroDetails'])).to.deep.equal({
-      fragmentName: 'HeroDetails',
-      typeCondition: 'Character',
-      possibleTypes: ['Human', 'Droid'],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'name',
-          fieldName: 'name',
-          type: 'String!'
-        }
-      ],
-      fragmentSpreads: [],
-      inlineFragments: [
-        {
-          typeCondition: 'Droid',
-          possibleTypes: ['Droid'],
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            },
-            {
-              responseName: 'primaryFunction',
-              fieldName: 'primaryFunction',
-              type: 'String'
-            },
-          ],
-          fragmentSpreads: []
-        },
-        {
-          typeCondition: 'Human',
-          possibleTypes: ['Human'],
-          fields: [
-            {
-              responseName: 'name',
-              fieldName: 'name',
-              type: 'String!'
-            },
-            {
-              responseName: 'height',
-              fieldName: 'height',
-              type: 'Float'
-            },
-          ],
-          fragmentSpreads: []
-        }
-      ]
-    });
+    expect(filteredIR(operations['Hero'])).toMatchSnapshot();
+    expect(filteredIR(fragments['HeroDetails'])).toMatchSnapshot();
   });
 
   it(`should inherit type condition when nesting an inline fragment in an inline fragment with a more specific type condition`, () => {
@@ -770,35 +363,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroName'])).to.deep.equal({
-      operationName: 'HeroName',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [],
-          fragmentSpreads: [],
-          inlineFragments: [
-            {
-              typeCondition: 'Droid',
-              possibleTypes: ['Droid'],
-              fields: [
-                {
-                  responseName: 'name',
-                  fieldName: 'name',
-                  type: 'String!'
-                }
-              ],
-              fragmentSpreads: []
-            }
-          ]
-        }
-      ]
-    });
+    expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
   it(`should not inherit type condition when nesting an inline fragment in an inline fragment with a less specific type condition`, () => {
@@ -816,35 +381,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroName'])).to.deep.equal({
-      operationName: 'HeroName',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: [],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [],
-          fragmentSpreads: [],
-          inlineFragments: [
-            {
-              typeCondition: 'Droid',
-              possibleTypes: ['Droid'],
-              fields: [
-                {
-                  responseName: 'name',
-                  fieldName: 'name',
-                  type: 'String!'
-                }
-              ],
-              fragmentSpreads: [],
-            }
-          ]
-        }
-      ]
-    });
+    expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
   it(`should inherit type condition when nesting a fragment spread in an inline fragment with a more specific type condition`, () => {
@@ -864,29 +401,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['HeroName'])).to.deep.equal({
-      operationName: 'HeroName',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['HeroName'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [],
-          fragmentSpreads: [],
-          inlineFragments: [
-            {
-              typeCondition: 'Droid',
-              possibleTypes: ['Droid'],
-              fragmentSpreads: ['HeroName'],
-              fields: [],
-            }
-          ]
-        }
-      ]
-    });
+    expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
   it(`should not inherit type condition when nesting a fragment spread in an inline fragment with a less specific type condition`, () => {
@@ -905,23 +420,7 @@ describe('Compiling query documents', () => {
     `);
 
     const { operations } = compileToIR(schema, document);
-
-    expect(filteredIR(operations['HeroName'])).to.deep.equal({
-      operationName: 'HeroName',
-      operationType: 'query',
-      variables: [],
-      fragmentsReferenced: ['DroidName'],
-      fields: [
-        {
-          responseName: 'hero',
-          fieldName: 'hero',
-          type: 'Character',
-          fields: [],
-          fragmentSpreads: ['DroidName'],
-          inlineFragments: []
-        }
-      ]
-    });
+    expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
   it(`should include type conditions for inline fragments on a union type`, () => {
@@ -943,42 +442,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(filteredIR(operations['Search']).fields[0].inlineFragments).to.deep.equal([
-      {
-        typeCondition: 'Droid',
-        possibleTypes: ['Droid'],
-        fields: [
-          {
-            responseName: 'name',
-            fieldName: 'name',
-            type: 'String!'
-          },
-          {
-            responseName: 'primaryFunction',
-            fieldName: 'primaryFunction',
-            type: 'String'
-          },
-        ],
-        fragmentSpreads: [],
-      },
-      {
-        typeCondition: 'Human',
-        possibleTypes: ['Human'],
-        fields: [
-          {
-            responseName: 'name',
-            fieldName: 'name',
-            type: 'String!'
-          },
-          {
-            responseName: 'height',
-            fieldName: 'height',
-            type: 'Float'
-          },
-        ],
-        fragmentSpreads: [],
-      }
-    ]);
+    expect(filteredIR(operations['Search']).fields[0].inlineFragments).toMatchSnapshot();
   });
 
   it(`should keep track of fragments referenced in a subselection`, () => {
@@ -999,7 +463,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroAndFriends'].fragmentsReferenced).to.deep.equal(['HeroDetails']);
+    expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails']);
   });
 
   it(`should keep track of fragments referenced in a fragment within a subselection`, () => {
@@ -1023,7 +487,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroAndFriends'].fragmentsReferenced).to.deep.equal(['HeroDetails', 'HeroName']);
+    expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails', 'HeroName']);
   });
 
   it(`should keep track of fragments referenced in a subselection nested in an inline fragment`, () => {
@@ -1046,7 +510,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroAndFriends'].fragmentsReferenced).to.deep.equal(['HeroDetails']);
+    expect(operations['HeroAndFriends'].fragmentsReferenced).toEqual(['HeroDetails']);
   });
 
   it(`should include the source of operations with __typename added for abstract types`, () => {
@@ -1061,7 +525,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroName'].source).to.equal(stripIndent`
+    expect(operations['HeroName'].source).toBe(stripIndent`
       query HeroName {
         hero {
           __typename
@@ -1081,7 +545,7 @@ describe('Compiling query documents', () => {
 
     const { fragments } = compileToIR(schema, document);
 
-    expect(fragments['HeroDetails'].source).to.equal(stripIndent`
+    expect(fragments['HeroDetails'].source).toBe(stripIndent`
       fragment HeroDetails on Character {
         __typename
         name
@@ -1101,7 +565,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['HeroName'].operationType).to.equal('query');
+    expect(operations['HeroName'].operationType).toBe('query');
   });
 
   it(`should include the operationType for a mutation`, () => {
@@ -1117,7 +581,7 @@ describe('Compiling query documents', () => {
 
     const { operations } = compileToIR(schema, document);
 
-    expect(operations['CreateReview'].operationType).to.equal('mutation');
+    expect(operations['CreateReview'].operationType).toBe('mutation');
   });
 });
 

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Flow code generation #generateSource() should annotate custom scalars as string 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type CustomScalarQuery = {|
+  misc: ? {|
+    date: ?any,
+  |},
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate correct typedefs with a multiple custom fragments 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export type HeroAndFriendsNamesQueryVariables = {|
+  episode: ?Episode,
+|};
+
+export type HeroAndFriendsNamesQuery = {|
+  hero: ? {|
+    // The name of the character
+    name: string,
+    // The friends of the character, or an empty list if they have none
+    friends: Array<{|
+      ...FriendFragment,
+      ...PersonFragment,
+    |}>,
+  |},
+|};
+
+export type FriendFragment = {|
+  // The name of the character
+  name: string,
+|};
+
+export type PersonFragment = {|
+  // The name of the character
+  name: string,
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate correct typedefs with a single custom fragment 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export type HeroAndFriendsNamesQueryVariables = {|
+  episode: ?Episode,
+|};
+
+export type HeroAndFriendsNamesQuery = {|
+  hero: ? {|
+    // The name of the character
+    name: string,
+    // The friends of the character, or an empty list if they have none
+    friends: Array<FriendFragment>,
+  |},
+|};
+
+export type FriendFragment = {|
+  // The name of the character
+  name: string,
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate fragmented query operations 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type HeroAndFriendsNamesQuery = {|
+  hero: ? {|
+    ...HeroFriendsFragment,
+    // The name of the character
+    name: string,
+  |},
+|};
+
+export type HeroFriendsFragment = {|
+  // The friends of the character, or an empty list if they have none
+  friends: ?Array< {|
+    // The name of the character
+    name: string,
+  |} >,
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate mutation operations with complex input types 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export type ReviewInput = {|
+  // 0-5 stars
+  stars: number,
+  // Comment about the movie, optional
+  commentary: ?string,
+  // Favorite color, optional
+  favorite_color: ?ColorInput,
+|};
+
+export type ColorInput = {|
+  red: number,
+  green: number,
+  blue: number,
+|};
+
+export type ReviewMovieMutationVariables = {|
+  episode: ?Episode,
+  review: ?ReviewInput,
+|};
+
+export type ReviewMovieMutation = {|
+  createReview: ? {|
+    // The number of stars this review gave, 1-5
+    stars: number,
+    // Comment about the movie
+    commentary: ?string,
+  |},
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate query operations with inline fragments 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type HeroAndDetailsQuery = {|
+  hero: ? {|
+    ...HeroDetailsFragment,
+    // The name of the character
+    name: string,
+  |},
+|};
+
+export type HeroDetailsFragment = {|
+  // This droid's primary function
+  primaryFunction: ?string,
+  // Height in the preferred unit, default is meters
+  height: ?number,
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate simple nested query operations including input variables 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export type HeroAndFriendsNamesQueryVariables = {|
+  episode: ?Episode,
+|};
+
+export type HeroAndFriendsNamesQuery = {|
+  hero: ? {|
+    // The name of the character
+    name: string,
+    // The friends of the character, or an empty list if they have none
+    friends: ?Array< {|
+      // The name of the character
+      name: string,
+    |} >,
+  |},
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate simple query operations 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type HeroNameQuery = {|
+  hero: ? {|
+    // The name of the character
+    name: string,
+  |},
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should generate simple query operations including input variables 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export type HeroNameQueryVariables = {|
+  episode: ?Episode,
+|};
+
+export type HeroNameQuery = {|
+  hero: ? {|
+    // The name of the character
+    name: string,
+  |},
+|};"
+`;

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -1,5 +1,3 @@
-import { stripIndent } from 'common-tags';
-
 import {
   parse,
   isType,
@@ -40,7 +38,7 @@ function setup(schema) {
   };
 
   const addFragment = (fragment) => {
-    this.generator.context.fragments[fragment.fragmentName] = fragment;
+    generator.context.fragments[fragment.fragmentName] = fragment;
   };
 
   return { generator, compileFromSource, addFragment };
@@ -48,7 +46,7 @@ function setup(schema) {
 
 describe('Flow code generation', function() {
   describe('#generateSource()', function() {
-    it(`should generate simple query operations`, function() {
+    test(`should generate simple query operations`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         query HeroName {
@@ -62,7 +60,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate simple query operations including input variables`, function() {
+    test(`should generate simple query operations including input variables`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         query HeroName($episode: Episode) {
@@ -76,7 +74,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate simple nested query operations including input variables`, function() {
+    test(`should generate simple nested query operations including input variables`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         query HeroAndFriendsNames($episode: Episode) {
@@ -93,7 +91,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate fragmented query operations`, function() {
+    test(`should generate fragmented query operations`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         query HeroAndFriendsNames {
@@ -114,7 +112,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate query operations with inline fragments`, function() {
+    test(`should generate query operations with inline fragments`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         query HeroAndDetails {
@@ -138,7 +136,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate mutation operations with complex input types`, function() {
+    test(`should generate mutation operations with complex input types`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         mutation ReviewMovie($episode: Episode, $review: ReviewInput) {
@@ -153,7 +151,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate correct typedefs with a single custom fragment`, function() {
+    test(`should generate correct typedefs with a single custom fragment`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         fragment Friend on Character {
@@ -174,7 +172,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate correct typedefs with a multiple custom fragments`, function() {
+    test(`should generate correct typedefs with a multiple custom fragments`, function() {
       const { compileFromSource } = setup(swapiSchema);
       const context = compileFromSource(`
         fragment Friend on Character {
@@ -200,7 +198,7 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should annotate custom scalars as string`, function() {
+    test(`should annotate custom scalars as string`, function() {
       const { compileFromSource } = setup(miscSchema);
       const context = compileFromSource(`
         query CustomScalar {

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import { stripIndent } from 'common-tags';
 
 import {
@@ -61,17 +59,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        export type HeroNameQuery = {|
-          hero: ? {|
-            name: string,
-          |},
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate simple query operations including input variables`, function() {
@@ -85,28 +73,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export type HeroNameQueryVariables = {|
-          episode: ?Episode,
-        |};
-
-        export type HeroNameQuery = {|
-          hero: ? {|
-            name: string,
-          |},
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate simple nested query operations including input variables`, function() {
@@ -123,31 +90,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export type HeroAndFriendsNamesQueryVariables = {|
-          episode: ?Episode,
-        |};
-
-        export type HeroAndFriendsNamesQuery = {|
-          hero: ? {|
-            name: string,
-            friends: ?Array< {|
-              name: string,
-            |} >,
-          |},
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate fragmented query operations`, function() {
@@ -168,24 +111,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        export type HeroAndFriendsNamesQuery = {|
-          hero: ? {|
-            ...HeroFriendsFragment,
-            name: string,
-          |},
-        |};
-
-        export type HeroFriendsFragment = {|
-          friends: ?Array< {|
-            name: string,
-          |} >,
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate query operations with inline fragments`, function() {
@@ -209,23 +135,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        export type HeroAndDetailsQuery = {|
-          hero: ? {|
-            ...HeroDetailsFragment,
-            name: string,
-          |},
-        |};
-
-        export type HeroDetailsFragment = {|
-          primaryFunction: ?string,
-          height: ?number,
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate mutation operations with complex input types`, function() {
@@ -240,45 +150,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export type ReviewInput = {|
-          // 0-5 stars
-          stars: number,
-          // Comment about the movie, optional
-          commentary: ?string,
-          // Favorite color, optional
-          favorite_color: ?ColorInput,
-        |};
-
-        export type ColorInput = {|
-          red: number,
-          green: number,
-          blue: number,
-        |};
-
-        export type ReviewMovieMutationVariables = {|
-          episode: ?Episode,
-          review: ?ReviewInput,
-        |};
-
-        export type ReviewMovieMutation = {|
-          createReview: ? {|
-            stars: number,
-            commentary: ?string,
-          |},
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate correct typedefs with a single custom fragment`, function() {
@@ -299,33 +171,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export type HeroAndFriendsNamesQueryVariables = {|
-          episode: ?Episode,
-        |};
-
-        export type HeroAndFriendsNamesQuery = {|
-          hero: ? {|
-            name: string,
-            friends: Array<FriendFragment>,
-          |},
-        |};
-
-        export type FriendFragment = {|
-          name: string,
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate correct typedefs with a multiple custom fragments`, function() {
@@ -351,40 +197,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export type HeroAndFriendsNamesQueryVariables = {|
-          episode: ?Episode,
-        |};
-
-        export type HeroAndFriendsNamesQuery = {|
-          hero: ? {|
-            name: string,
-            friends: Array<{|
-              ...FriendFragment,
-              ...PersonFragment,
-            |}>,
-          |},
-        |};
-
-        export type FriendFragment = {|
-          name: string,
-        |};
-
-        export type PersonFragment = {|
-          name: string,
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should annotate custom scalars as string`, function() {
@@ -398,17 +211,7 @@ describe('Flow code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        /* @flow */
-        //  This file was automatically generated and should not be edited.
-
-        export type CustomScalarQuery = {|
-          misc: ? {|
-            date: ?any,
-          |},
-        |};
-      `);
+      expect(source).toMatchSnapshot();
     });
   });
 });

--- a/test/introspectSchema.js
+++ b/test/introspectSchema.js
@@ -1,16 +1,15 @@
-import chai, { expect } from 'chai'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
 import { introspect } from '../src/introspectSchema';
 
 describe('Introspecting GraphQL schema documents', () => {
-  it(`should generate valid introspection JSON file`, async () => {
+  test(`should generate valid introspection JSON file`, async () => {
     const schemaContents = readFileSync(join(__dirname, './starwars/schema.graphql')).toString();
     const expected = readFileSync(join(__dirname, './starwars/schema.json')).toString();
 
     const schema = await introspect(schemaContents);
 
-    expect(JSON.stringify(schema, null, 2)).to.be.equal(expected);
+    expect(JSON.stringify(schema, null, 2)).toEqual(expected);
   });
 })

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -1,0 +1,534 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
+"public final class CreateReviewMutation: GraphQLMutation {
+  public static let operationDefinition =
+    \\"mutation CreateReview($episode: Episode) {\\" +
+    \\"  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\" +
+    \\"    __typename\\" +
+    \\"    stars\\" +
+    \\"    commentary\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  public let episode: Episode?
+
+  public init(episode: Episode? = nil) {
+    self.episode = episode
+  }
+
+  public var variables: GraphQLMap? {
+    return [\\"episode\\": episode]
+  }
+
+  public struct Data: GraphQLMappable {
+    public let createReview: CreateReview?
+
+    public init(reader: GraphQLResultReader) throws {
+      createReview = try reader.optionalValue(for: Field(responseName: \\"createReview\\", arguments: [\\"episode\\": reader.variables[\\"episode\\"], \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\"]]))
+    }
+
+    public struct CreateReview: GraphQLMappable {
+      public let __typename: String
+      public let stars: Int /// The number of stars this review gave, 1-5
+      public let commentary: String? /// Comment about the movie
+
+      public init(reader: GraphQLResultReader) throws {
+        __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+        stars = try reader.value(for: Field(responseName: \\"stars\\"))
+        commentary = try reader.optionalValue(for: Field(responseName: \\"commentary\\"))
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+  public static let operationDefinition =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    __typename\\" +
+    \\"    ... on Droid {\\" +
+    \\"      __typename\\" +
+    \\"      ...HeroDetails\\" +
+    \\"    }\\" +
+    \\"  }\\" +
+    \\"}\\"
+  public static let queryDocument = operationDefinition.appending(HeroDetails.fragmentDefinition)
+  public init() {
+  }
+
+  public struct Data: GraphQLMappable {
+    public let hero: Hero?
+
+    public init(reader: GraphQLResultReader) throws {
+      hero = try reader.optionalValue(for: Field(responseName: \\"hero\\"))
+    }
+
+    public struct Hero: GraphQLMappable {
+      public let __typename: String
+
+      public let asDroid: AsDroid?
+
+      public init(reader: GraphQLResultReader) throws {
+        __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+        asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
+      }
+
+      public struct AsDroid: GraphQLConditionalFragment {
+        public static let possibleTypes = [\\"Droid\\"]
+
+        public let __typename: String
+
+        public let fragments: Fragments
+
+        public init(reader: GraphQLResultReader) throws {
+          __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+          let heroDetails = try HeroDetails(reader: reader)
+          fragments = Fragments(heroDetails: heroDetails)
+        }
+
+        public struct Fragments {
+          public let heroDetails: HeroDetails
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+  public static let operationDefinition =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    __typename\\" +
+    \\"    ...DroidDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+  public static let queryDocument = operationDefinition.appending(DroidDetails.fragmentDefinition)
+  public init() {
+  }
+
+  public struct Data: GraphQLMappable {
+    public let hero: Hero?
+
+    public init(reader: GraphQLResultReader) throws {
+      hero = try reader.optionalValue(for: Field(responseName: \\"hero\\"))
+    }
+
+    public struct Hero: GraphQLMappable {
+      public let __typename: String
+
+      public let fragments: Fragments
+
+      public init(reader: GraphQLResultReader) throws {
+        __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+        let droidDetails = try DroidDetails(reader: reader, ifTypeMatches: __typename)
+        fragments = Fragments(droidDetails: droidDetails)
+      }
+
+      public struct Fragments {
+        public let droidDetails: DroidDetails?
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+  public static let operationDefinition =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    __typename\\" +
+    \\"    ...HeroDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+  public static let queryDocument = operationDefinition.appending(HeroDetails.fragmentDefinition)
+  public init() {
+  }
+
+  public struct Data: GraphQLMappable {
+    public let hero: Hero?
+
+    public init(reader: GraphQLResultReader) throws {
+      hero = try reader.optionalValue(for: Field(responseName: \\"hero\\"))
+    }
+
+    public struct Hero: GraphQLMappable {
+      public let __typename: String
+
+      public let fragments: Fragments
+
+      public init(reader: GraphQLResultReader) throws {
+        __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+        let heroDetails = try HeroDetails(reader: reader)
+        fragments = Fragments(heroDetails: heroDetails)
+      }
+
+      public struct Fragments {
+        public let heroDetails: HeroDetails
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
+"public final class HeroNameQuery: GraphQLQuery {
+  public static let operationDefinition =
+    \\"query HeroName($episode: Episode) {\\" +
+    \\"  hero(episode: $episode) {\\" +
+    \\"    __typename\\" +
+    \\"    name\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  public let episode: Episode?
+
+  public init(episode: Episode? = nil) {
+    self.episode = episode
+  }
+
+  public var variables: GraphQLMap? {
+    return [\\"episode\\": episode]
+  }
+
+  public struct Data: GraphQLMappable {
+    public let hero: Hero?
+
+    public init(reader: GraphQLResultReader) throws {
+      hero = try reader.optionalValue(for: Field(responseName: \\"hero\\", arguments: [\\"episode\\": reader.variables[\\"episode\\"]]))
+    }
+
+    public struct Hero: GraphQLMappable {
+      public let __typename: String
+      public let name: String /// The name of the character
+
+      public init(reader: GraphQLResultReader) throws {
+        __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+        name = try reader.value(for: Field(responseName: \\"name\\"))
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for a property 1`] = `
+"public init(episode: Episode) {
+  self.episode = episode
+}"
+`;
+
+exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for an optional property 1`] = `
+"public init(episode: Episode? = nil) {
+  self.episode = episode
+}"
+`;
+
+exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for multiple properties 1`] = `
+"public init(episode: Episode? = nil, scene: String? = nil) {
+  self.episode = episode
+  self.scene = scene
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
+"public struct HeroDetails: GraphQLNamedFragment {
+  public static let fragmentDefinition =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  __typename\\" +
+    \\"  name\\" +
+    \\"  ...MoreHeroDetails\\" +
+    \\"}\\"
+
+  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+  public let __typename: String
+  public let name: String /// The name of the character
+
+  public let fragments: Fragments
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.value(for: Field(responseName: \\"name\\"))
+
+    let moreHeroDetails = try MoreHeroDetails(reader: reader)
+    fragments = Fragments(moreHeroDetails: moreHeroDetails)
+  }
+
+  public struct Fragments {
+    public let moreHeroDetails: MoreHeroDetails
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
+"public struct DroidDetails: GraphQLNamedFragment {
+  public static let fragmentDefinition =
+    \\"fragment DroidDetails on Droid {\\" +
+    \\"  __typename\\" +
+    \\"  name\\" +
+    \\"  primaryFunction\\" +
+    \\"}\\"
+
+  public static let possibleTypes = [\\"Droid\\"]
+
+  public let __typename: String
+  public let name: String /// What others call this droid
+  public let primaryFunction: String? /// This droid's primary function
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.value(for: Field(responseName: \\"name\\"))
+    primaryFunction = try reader.optionalValue(for: Field(responseName: \\"primaryFunction\\"))
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
+"public struct HeroDetails: GraphQLNamedFragment {
+  public static let fragmentDefinition =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  __typename\\" +
+    \\"  name\\" +
+    \\"  friends {\\" +
+    \\"    __typename\\" +
+    \\"    name\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+  public let __typename: String
+  public let name: String /// The name of the character
+  public let friends: [Friend?]? /// The friends of the character, or an empty list if they have none
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.value(for: Field(responseName: \\"name\\"))
+    friends = try reader.optionalList(for: Field(responseName: \\"friends\\"))
+  }
+
+  public struct Friend: GraphQLMappable {
+    public let __typename: String
+    public let name: String /// The name of the character
+
+    public init(reader: GraphQLResultReader) throws {
+      __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+      name = try reader.value(for: Field(responseName: \\"name\\"))
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
+"public struct HeroDetails: GraphQLNamedFragment {
+  public static let fragmentDefinition =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  __typename\\" +
+    \\"  name\\" +
+    \\"  appearsIn\\" +
+    \\"}\\"
+
+  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+  public let __typename: String
+  public let name: String /// The name of the character
+  public let appearsIn: [Episode?] /// The movies this character appears in
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.value(for: Field(responseName: \\"name\\"))
+    appearsIn = try reader.list(for: Field(responseName: \\"appearsIn\\"))
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should escape reserved keywords in a struct declaration for a selection set 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let \`private\`: String?
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    \`private\` = try reader.optionalValue(for: Field(responseName: \\"private\\", fieldName: \\"name\\"))
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a nested struct declaration for a selection set with subselections 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let friends: [Friend?]?
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    friends = try reader.optionalList(for: Field(responseName: \\"friends\\"))
+  }
+
+  public struct Friend: GraphQLMappable {
+    public let __typename: String
+    public let name: String?
+
+    public init(reader: GraphQLResultReader) throws {
+      __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+      name = try reader.optionalValue(for: Field(responseName: \\"name\\"))
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a fragment spread nested in an inline fragment 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+
+  public let asDroid: AsDroid?
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+    asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
+  }
+
+  public struct AsDroid: GraphQLConditionalFragment {
+    public static let possibleTypes = [\\"Droid\\"]
+
+    public let __typename: String
+
+    public let fragments: Fragments
+
+    public init(reader: GraphQLResultReader) throws {
+      __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+
+      let heroDetails = try HeroDetails(reader: reader)
+      fragments = Fragments(heroDetails: heroDetails)
+    }
+
+    public struct Fragments {
+      public let heroDetails: HeroDetails
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let name: String?
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.optionalValue(for: Field(responseName: \\"name\\"))
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread that matches the parent type 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let name: String?
+
+  public let fragments: Fragments
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.optionalValue(for: Field(responseName: \\"name\\"))
+
+    let heroDetails = try HeroDetails(reader: reader)
+    fragments = Fragments(heroDetails: heroDetails)
+  }
+
+  public struct Fragments {
+    public let heroDetails: HeroDetails
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread with a more specific type condition 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let name: String?
+
+  public let fragments: Fragments
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.optionalValue(for: Field(responseName: \\"name\\"))
+
+    let droidDetails = try DroidDetails(reader: reader, ifTypeMatches: __typename)
+    fragments = Fragments(droidDetails: droidDetails)
+  }
+
+  public struct Fragments {
+    public let droidDetails: DroidDetails?
+  }
+}"
+`;
+
+exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with an inline fragment 1`] = `
+"public struct Hero: GraphQLMappable {
+  public let __typename: String
+  public let name: String
+
+  public let asDroid: AsDroid?
+
+  public init(reader: GraphQLResultReader) throws {
+    __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+    name = try reader.value(for: Field(responseName: \\"name\\"))
+
+    asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
+  }
+
+  public struct AsDroid: GraphQLConditionalFragment {
+    public static let possibleTypes = [\\"Droid\\"]
+
+    public let __typename: String
+    public let name: String
+    public let primaryFunction: String?
+
+    public init(reader: GraphQLResultReader) throws {
+      __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
+      name = try reader.value(for: Field(responseName: \\"name\\"))
+      primaryFunction = try reader.optionalValue(for: Field(responseName: \\"primaryFunction\\"))
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
+"public enum AlbumPrivacies: String {
+  case \`public\` = \\"PUBLIC\\"
+  case \`private\` = \\"PRIVATE\\"
+}
+
+extension AlbumPrivacies: JSONDecodable, JSONEncodable {}"
+`;
+
+exports[`Swift code generation #typeDeclarationForGraphQLType() should generate a struct declaration for a GraphQLInputObjectType 1`] = `
+"/// The input object sent when someone is creating a new review
+public struct ReviewInput: GraphQLMapConvertible {
+  public var graphQLMap: GraphQLMap
+
+  public init(stars: Int, commentary: String? = nil, favoriteColor: ColorInput? = nil) {
+    graphQLMap = [\\"stars\\": stars, \\"commentary\\": commentary, \\"favorite_color\\": favoriteColor]
+  }
+}"
+`;
+
+exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
+"/// The episodes in the Star Wars trilogy
+public enum Episode: String {
+  case newhope = \\"NEWHOPE\\" /// Star Wars Episode IV: A New Hope, released in 1977.
+  case empire = \\"EMPIRE\\" /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  case jedi = \\"JEDI\\" /// Star Wars Episode VI: Return of the Jedi, released in 1983.
+}
+
+extension Episode: JSONDecodable, JSONEncodable {}"
+`;

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import { stripIndent } from 'common-tags';
 
 import {
@@ -64,27 +62,7 @@ describe('Swift code generation', function() {
       `);
 
       classDeclarationForOperation(this.generator, operations['HeroName']);
-
-      expect(this.generator.output).to.include(stripIndent`
-        public final class HeroNameQuery: GraphQLQuery {
-          public static let operationDefinition =
-            "query HeroName($episode: Episode) {" +
-            "  hero(episode: $episode) {" +
-            "    __typename" +
-            "    name" +
-            "  }" +
-            "}"
-
-          public let episode: Episode?
-
-          public init(episode: Episode? = nil) {
-            self.episode = episode
-          }
-
-          public var variables: GraphQLMap? {
-            return ["episode": episode]
-          }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a class declaration for a query with fragment spreads`, function() {
@@ -101,46 +79,7 @@ describe('Swift code generation', function() {
       `);
 
       classDeclarationForOperation(this.generator, operations['Hero']);
-
-      expect(this.generator.output).to.equal(stripIndent`
-        public final class HeroQuery: GraphQLQuery {
-          public static let operationDefinition =
-            "query Hero {" +
-            "  hero {" +
-            "    __typename" +
-            "    ...HeroDetails" +
-            "  }" +
-            "}"
-          public static let queryDocument = operationDefinition.appending(HeroDetails.fragmentDefinition)
-          public init() {
-          }
-
-          public struct Data: GraphQLMappable {
-            public let hero: Hero?
-
-            public init(reader: GraphQLResultReader) throws {
-              hero = try reader.optionalValue(for: Field(responseName: "hero"))
-            }
-
-            public struct Hero: GraphQLMappable {
-              public let __typename: String
-
-              public let fragments: Fragments
-
-              public init(reader: GraphQLResultReader) throws {
-                __typename = try reader.value(for: Field(responseName: "__typename"))
-
-                let heroDetails = try HeroDetails(reader: reader)
-                fragments = Fragments(heroDetails: heroDetails)
-              }
-
-              public struct Fragments {
-                public let heroDetails: HeroDetails
-              }
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a class declaration for a query with conditional fragment spreads`, function() {
@@ -157,46 +96,7 @@ describe('Swift code generation', function() {
       `);
 
       classDeclarationForOperation(this.generator, operations['Hero']);
-
-      expect(this.generator.output).to.equal(stripIndent`
-        public final class HeroQuery: GraphQLQuery {
-          public static let operationDefinition =
-            "query Hero {" +
-            "  hero {" +
-            "    __typename" +
-            "    ...DroidDetails" +
-            "  }" +
-            "}"
-          public static let queryDocument = operationDefinition.appending(DroidDetails.fragmentDefinition)
-          public init() {
-          }
-
-          public struct Data: GraphQLMappable {
-            public let hero: Hero?
-
-            public init(reader: GraphQLResultReader) throws {
-              hero = try reader.optionalValue(for: Field(responseName: "hero"))
-            }
-
-            public struct Hero: GraphQLMappable {
-              public let __typename: String
-
-              public let fragments: Fragments
-
-              public init(reader: GraphQLResultReader) throws {
-                __typename = try reader.value(for: Field(responseName: "__typename"))
-
-                let droidDetails = try DroidDetails(reader: reader, ifTypeMatches: __typename)
-                fragments = Fragments(droidDetails: droidDetails)
-              }
-
-              public struct Fragments {
-                public let droidDetails: DroidDetails?
-              }
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
@@ -216,62 +116,7 @@ describe('Swift code generation', function() {
 
       classDeclarationForOperation(this.generator, operations['Hero']);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public final class HeroQuery: GraphQLQuery {
-          public static let operationDefinition =
-            "query Hero {" +
-            "  hero {" +
-            "    __typename" +
-            "    ... on Droid {" +
-            "      __typename" +
-            "      ...HeroDetails" +
-            "    }" +
-            "  }" +
-            "}"
-          public static let queryDocument = operationDefinition.appending(HeroDetails.fragmentDefinition)
-          public init() {
-          }
-
-          public struct Data: GraphQLMappable {
-            public let hero: Hero?
-
-            public init(reader: GraphQLResultReader) throws {
-              hero = try reader.optionalValue(for: Field(responseName: "hero"))
-            }
-
-            public struct Hero: GraphQLMappable {
-              public let __typename: String
-
-              public let asDroid: AsDroid?
-
-              public init(reader: GraphQLResultReader) throws {
-                __typename = try reader.value(for: Field(responseName: "__typename"))
-
-                asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
-              }
-
-              public struct AsDroid: GraphQLConditionalFragment {
-                public static let possibleTypes = ["Droid"]
-
-                public let __typename: String
-
-                public let fragments: Fragments
-
-                public init(reader: GraphQLResultReader) throws {
-                  __typename = try reader.value(for: Field(responseName: "__typename"))
-
-                  let heroDetails = try HeroDetails(reader: reader)
-                  fragments = Fragments(heroDetails: heroDetails)
-                }
-
-                public struct Fragments {
-                  public let heroDetails: HeroDetails
-                }
-              }
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a class declaration for a mutation with variables`, function() {
@@ -286,27 +131,7 @@ describe('Swift code generation', function() {
 
       classDeclarationForOperation(this.generator, operations['CreateReview']);
 
-      expect(this.generator.output).to.include(stripIndent`
-        public final class CreateReviewMutation: GraphQLMutation {
-          public static let operationDefinition =
-            "mutation CreateReview($episode: Episode) {" +
-            "  createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {" +
-            "    __typename" +
-            "    stars" +
-            "    commentary" +
-            "  }" +
-            "}"
-
-          public let episode: Episode?
-
-          public init(episode: Episode? = nil) {
-            self.episode = episode
-          }
-
-          public var variables: GraphQLMap? {
-            return ["episode": episode]
-          }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
   });
 
@@ -316,11 +141,7 @@ describe('Swift code generation', function() {
         { propertyName: 'episode', type: new GraphQLNonNull(schema.getType('Episode')), typeName: 'Episode' }
       ]);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public init(episode: Episode) {
-          self.episode = episode
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate initializer for an optional property`, function() {
@@ -328,11 +149,7 @@ describe('Swift code generation', function() {
         { propertyName: 'episode', type: schema.getType('Episode'), typeName: 'Episode?', isOptional: true }
       ]);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public init(episode: Episode? = nil) {
-          self.episode = episode
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate initializer for multiple properties`, function() {
@@ -341,12 +158,7 @@ describe('Swift code generation', function() {
         { propertyName: 'scene', type: GraphQLString, typeName: 'String?', isOptional: true }
       ]);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public init(episode: Episode? = nil, scene: String? = nil) {
-          self.episode = episode
-          self.scene = scene
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
   });
 
@@ -361,28 +173,7 @@ describe('Swift code generation', function() {
 
       structDeclarationForFragment(this.generator, fragments['HeroDetails']);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct HeroDetails: GraphQLNamedFragment {
-          public static let fragmentDefinition =
-            "fragment HeroDetails on Character {" +
-            "  __typename" +
-            "  name" +
-            "  appearsIn" +
-            "}"
-
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public let __typename: String
-          public let name: String
-          public let appearsIn: [Episode?]
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.value(for: Field(responseName: "name"))
-            appearsIn = try reader.list(for: Field(responseName: "appearsIn"))
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a fragment with a concrete type condition`, function() {
@@ -395,28 +186,7 @@ describe('Swift code generation', function() {
 
       structDeclarationForFragment(this.generator, fragments['DroidDetails']);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct DroidDetails: GraphQLNamedFragment {
-          public static let fragmentDefinition =
-            "fragment DroidDetails on Droid {" +
-            "  __typename" +
-            "  name" +
-            "  primaryFunction" +
-            "}"
-
-          public static let possibleTypes = ["Droid"]
-
-          public let __typename: String
-          public let name: String
-          public let primaryFunction: String?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.value(for: Field(responseName: "name"))
-            primaryFunction = try reader.optionalValue(for: Field(responseName: "primaryFunction"))
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a fragment with a subselection`, function() {
@@ -431,41 +201,7 @@ describe('Swift code generation', function() {
 
       structDeclarationForFragment(this.generator, fragments['HeroDetails']);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct HeroDetails: GraphQLNamedFragment {
-          public static let fragmentDefinition =
-            "fragment HeroDetails on Character {" +
-            "  __typename" +
-            "  name" +
-            "  friends {" +
-            "    __typename" +
-            "    name" +
-            "  }" +
-            "}"
-
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public let __typename: String
-          public let name: String
-          public let friends: [Friend?]?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.value(for: Field(responseName: "name"))
-            friends = try reader.optionalList(for: Field(responseName: "friends"))
-          }
-
-          public struct Friend: GraphQLMappable {
-            public let __typename: String
-            public let name: String
-
-            public init(reader: GraphQLResultReader) throws {
-              __typename = try reader.value(for: Field(responseName: "__typename"))
-              name = try reader.value(for: Field(responseName: "name"))
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a fragment that includes a fragment spread`, function() {
@@ -482,35 +218,7 @@ describe('Swift code generation', function() {
 
       structDeclarationForFragment(this.generator, fragments['HeroDetails']);
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct HeroDetails: GraphQLNamedFragment {
-          public static let fragmentDefinition =
-            "fragment HeroDetails on Character {" +
-            "  __typename" +
-            "  name" +
-            "  ...MoreHeroDetails" +
-            "}"
-
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public let __typename: String
-          public let name: String
-
-          public let fragments: Fragments
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.value(for: Field(responseName: "name"))
-
-            let moreHeroDetails = try MoreHeroDetails(reader: reader)
-            fragments = Fragments(moreHeroDetails: moreHeroDetails)
-          }
-
-          public struct Fragments {
-            public let moreHeroDetails: MoreHeroDetails
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
   });
 
@@ -528,17 +236,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let name: String?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.optionalValue(for: Field(responseName: "name"))
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should escape reserved keywords in a struct declaration for a selection set`, function() {
@@ -554,17 +252,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let \`private\`: String?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            \`private\` = try reader.optionalValue(for: Field(responseName: "private", fieldName: "name"))
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a nested struct declaration for a selection set with subselections`, function() {
@@ -587,27 +275,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let friends: [Friend?]?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            friends = try reader.optionalList(for: Field(responseName: "friends"))
-          }
-
-          public struct Friend: GraphQLMappable {
-            public let __typename: String
-            public let name: String?
-
-            public init(reader: GraphQLResultReader) throws {
-              __typename = try reader.value(for: Field(responseName: "__typename"))
-              name = try reader.optionalValue(for: Field(responseName: "name"))
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a selection set with a fragment spread that matches the parent type`, function() {
@@ -629,26 +297,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let name: String?
-
-          public let fragments: Fragments
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.optionalValue(for: Field(responseName: "name"))
-
-            let heroDetails = try HeroDetails(reader: reader)
-            fragments = Fragments(heroDetails: heroDetails)
-          }
-
-          public struct Fragments {
-            public let heroDetails: HeroDetails
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a selection set with a fragment spread with a more specific type condition`, function() {
@@ -670,26 +319,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let name: String?
-
-          public let fragments: Fragments
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.optionalValue(for: Field(responseName: "name"))
-
-            let droidDetails = try DroidDetails(reader: reader, ifTypeMatches: __typename)
-            fragments = Fragments(droidDetails: droidDetails)
-          }
-
-          public struct Fragments {
-            public let droidDetails: DroidDetails?
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a selection set with an inline fragment`, function() {
@@ -723,35 +353,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-          public let name: String
-
-          public let asDroid: AsDroid?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-            name = try reader.value(for: Field(responseName: "name"))
-
-            asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
-          }
-
-          public struct AsDroid: GraphQLConditionalFragment {
-            public static let possibleTypes = ["Droid"]
-
-            public let __typename: String
-            public let name: String
-            public let primaryFunction: String?
-
-            public init(reader: GraphQLResultReader) throws {
-              __typename = try reader.value(for: Field(responseName: "__typename"))
-              name = try reader.value(for: Field(responseName: "name"))
-              primaryFunction = try reader.optionalValue(for: Field(responseName: "primaryFunction"))
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
 
     it(`should generate a struct declaration for a fragment spread nested in an inline fragment`, function() {
@@ -774,38 +376,7 @@ describe('Swift code generation', function() {
         ]
       });
 
-      expect(this.generator.output).to.equal(stripIndent`
-        public struct Hero: GraphQLMappable {
-          public let __typename: String
-
-          public let asDroid: AsDroid?
-
-          public init(reader: GraphQLResultReader) throws {
-            __typename = try reader.value(for: Field(responseName: "__typename"))
-
-            asDroid = try AsDroid(reader: reader, ifTypeMatches: __typename)
-          }
-
-          public struct AsDroid: GraphQLConditionalFragment {
-            public static let possibleTypes = ["Droid"]
-
-            public let __typename: String
-
-            public let fragments: Fragments
-
-            public init(reader: GraphQLResultReader) throws {
-              __typename = try reader.value(for: Field(responseName: "__typename"))
-
-              let heroDetails = try HeroDetails(reader: reader)
-              fragments = Fragments(heroDetails: heroDetails)
-            }
-
-            public struct Fragments {
-              public let heroDetails: HeroDetails
-            }
-          }
-        }
-      `);
+      expect(this.generator.output).toMatchSnapshot();
     });
   });
 
@@ -822,7 +393,7 @@ describe('Swift code generation', function() {
       const fieldArguments = operations['FieldArgumentsWithInputObjects'].fields[0].args;
       const dictionaryLiteral = dictionaryLiteralForFieldArguments(fieldArguments);
 
-      expect(dictionaryLiteral).to.equal('["episode": "JEDI", "review": ["stars": 2, "commentary": reader.variables["commentary"], "favorite_color": ["red": reader.variables["red"], "blue": 100, "green": 50]]]');
+      expect(dictionaryLiteral).toBe('["episode": "JEDI", "review": ["stars": 2, "commentary": reader.variables["commentary"], "favorite_color": ["red": reader.variables["red"], "blue": 100, "green": 50]]]');
     });
   });
 
@@ -832,16 +403,7 @@ describe('Swift code generation', function() {
 
       typeDeclarationForGraphQLType(generator, schema.getType('Episode'));
 
-      expect(generator.output).to.equal(stripIndent`
-        /// The episodes in the Star Wars trilogy
-        public enum Episode: String {
-          case newhope = "NEWHOPE" /// Star Wars Episode IV: A New Hope, released in 1977.
-          case empire = "EMPIRE" /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          case jedi = "JEDI" /// Star Wars Episode VI: Return of the Jedi, released in 1983.
-        }
-
-        extension Episode: JSONDecodable, JSONEncodable {}
-      `);
+      expect(generator.output).toMatchSnapshot();
     });
 
     it('should escape identifiers in cases of enum declaration for a GraphQLEnumType', function() {
@@ -854,14 +416,7 @@ describe('Swift code generation', function() {
 
       typeDeclarationForGraphQLType(generator, albumPrivaciesEnum);
 
-      expect(generator.output).to.equal(stripIndent`
-        public enum AlbumPrivacies: String {
-          case \`public\` = "PUBLIC"
-          case \`private\` = "PRIVATE"
-        }
-
-        extension AlbumPrivacies: JSONDecodable, JSONEncodable {}
-      `);
+      expect(generator.output).toMatchSnapshot();
     });
 
     it('should generate a struct declaration for a GraphQLInputObjectType', function() {
@@ -869,16 +424,7 @@ describe('Swift code generation', function() {
 
       typeDeclarationForGraphQLType(generator, schema.getType('ReviewInput'));
 
-      expect(generator.output).to.equal(stripIndent`
-        /// The input object sent when someone is creating a new review
-        public struct ReviewInput: GraphQLMapConvertible {
-          public var graphQLMap: GraphQLMap
-
-          public init(stars: Int, commentary: String? = nil, favoriteColor: ColorInput? = nil) {
-            graphQLMap = ["stars": stars, "commentary": commentary, "favorite_color": favoriteColor]
-          }
-        }
-      `);
+      expect(generator.output).toMatchSnapshot();
     });
   });
 });

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -52,7 +52,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#classDeclarationForOperation()', function() {
-    it(`should generate a class declaration for a query with variables`, function() {
+    test(`should generate a class declaration for a query with variables`, function() {
       const { operations } = this.compileFromSource(`
         query HeroName($episode: Episode) {
           hero(episode: $episode) {
@@ -65,7 +65,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a class declaration for a query with fragment spreads`, function() {
+    test(`should generate a class declaration for a query with fragment spreads`, function() {
       const { operations } = this.compileFromSource(`
         query Hero {
           hero {
@@ -82,7 +82,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a class declaration for a query with conditional fragment spreads`, function() {
+    test(`should generate a class declaration for a query with conditional fragment spreads`, function() {
       const { operations } = this.compileFromSource(`
         query Hero {
           hero {
@@ -99,7 +99,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
+    test(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
       const { operations } = this.compileFromSource(`
         query Hero {
           hero {
@@ -119,7 +119,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a class declaration for a mutation with variables`, function() {
+    test(`should generate a class declaration for a mutation with variables`, function() {
       const { operations } = this.compileFromSource(`
         mutation CreateReview($episode: Episode) {
           createReview(episode: $episode, review: { stars: 5, commentary: "Wow!" }) {
@@ -136,7 +136,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#initializerDeclarationForProperties()', function() {
-    it(`should generate initializer for a property`, function() {
+    test(`should generate initializer for a property`, function() {
       initializerDeclarationForProperties(this.generator, [
         { propertyName: 'episode', type: new GraphQLNonNull(schema.getType('Episode')), typeName: 'Episode' }
       ]);
@@ -144,7 +144,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate initializer for an optional property`, function() {
+    test(`should generate initializer for an optional property`, function() {
       initializerDeclarationForProperties(this.generator, [
         { propertyName: 'episode', type: schema.getType('Episode'), typeName: 'Episode?', isOptional: true }
       ]);
@@ -152,7 +152,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate initializer for multiple properties`, function() {
+    test(`should generate initializer for multiple properties`, function() {
       initializerDeclarationForProperties(this.generator, [
         { propertyName: 'episode', type: schema.getType('Episode'), typeName: 'Episode?', isOptional: true },
         { propertyName: 'scene', type: GraphQLString, typeName: 'String?', isOptional: true }
@@ -163,7 +163,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#structDeclarationForFragment()', function() {
-    it(`should generate a struct declaration for a fragment with an abstract type condition`, function() {
+    test(`should generate a struct declaration for a fragment with an abstract type condition`, function() {
       const { fragments } = this.compileFromSource(`
         fragment HeroDetails on Character {
           name
@@ -176,7 +176,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a fragment with a concrete type condition`, function() {
+    test(`should generate a struct declaration for a fragment with a concrete type condition`, function() {
       const { fragments } = this.compileFromSource(`
         fragment DroidDetails on Droid {
           name
@@ -189,7 +189,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a fragment with a subselection`, function() {
+    test(`should generate a struct declaration for a fragment with a subselection`, function() {
       const { fragments } = this.compileFromSource(`
         fragment HeroDetails on Character {
           name
@@ -204,7 +204,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a fragment that includes a fragment spread`, function() {
+    test(`should generate a struct declaration for a fragment that includes a fragment spread`, function() {
       const { fragments } = this.compileFromSource(`
         fragment HeroDetails on Character {
           name
@@ -223,7 +223,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#structDeclarationForSelectionSet()', function() {
-    it(`should generate a struct declaration for a selection set`, function() {
+    test(`should generate a struct declaration for a selection set`, function() {
       structDeclarationForSelectionSet(this.generator, {
         structName: 'Hero',
         parentType: schema.getType('Character'),
@@ -239,7 +239,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should escape reserved keywords in a struct declaration for a selection set`, function() {
+    test(`should escape reserved keywords in a struct declaration for a selection set`, function() {
       structDeclarationForSelectionSet(this.generator, {
         structName: 'Hero',
         parentType: schema.getType('Character'),
@@ -255,7 +255,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a nested struct declaration for a selection set with subselections`, function() {
+    test(`should generate a nested struct declaration for a selection set with subselections`, function() {
       structDeclarationForSelectionSet(this.generator, {
         structName: 'Hero',
         parentType: schema.getType('Character'),
@@ -278,7 +278,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a selection set with a fragment spread that matches the parent type`, function() {
+    test(`should generate a struct declaration for a selection set with a fragment spread that matches the parent type`, function() {
       this.addFragment({
         fragmentName: 'HeroDetails',
         typeCondition: schema.getType('Character')
@@ -300,7 +300,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a selection set with a fragment spread with a more specific type condition`, function() {
+    test(`should generate a struct declaration for a selection set with a fragment spread with a more specific type condition`, function() {
       this.addFragment({
         fragmentName: 'DroidDetails',
         typeCondition: schema.getType('Droid')
@@ -322,7 +322,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a selection set with an inline fragment`, function() {
+    test(`should generate a struct declaration for a selection set with an inline fragment`, function() {
       structDeclarationForSelectionSet(this.generator, {
         structName: 'Hero',
         parentType: schema.getType('Character'),
@@ -356,7 +356,7 @@ describe('Swift code generation', function() {
       expect(this.generator.output).toMatchSnapshot();
     });
 
-    it(`should generate a struct declaration for a fragment spread nested in an inline fragment`, function() {
+    test(`should generate a struct declaration for a fragment spread nested in an inline fragment`, function() {
       this.addFragment({
         fragmentName: 'HeroDetails',
         typeCondition: schema.getType('Character')
@@ -381,7 +381,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#dictionaryLiteralForFieldArguments()', function() {
-    it('should include expressions for input objects with variables', function() {
+    test('should include expressions for input objects with variables', function() {
       const { operations } = this.compileFromSource(`
         mutation FieldArgumentsWithInputObjects($commentary: String!, $red: Int!) {
           createReview(episode: JEDI, review: { stars: 2, commentary: $commentary, favorite_color: { red: $red, blue: 100, green: 50 } }) {
@@ -398,7 +398,7 @@ describe('Swift code generation', function() {
   });
 
   describe('#typeDeclarationForGraphQLType()', function() {
-    it('should generate an enum declaration for a GraphQLEnumType', function() {
+    test('should generate an enum declaration for a GraphQLEnumType', function() {
       const generator = new CodeGenerator();
 
       typeDeclarationForGraphQLType(generator, schema.getType('Episode'));
@@ -406,7 +406,7 @@ describe('Swift code generation', function() {
       expect(generator.output).toMatchSnapshot();
     });
 
-    it('should escape identifiers in cases of enum declaration for a GraphQLEnumType', function() {
+    test('should escape identifiers in cases of enum declaration for a GraphQLEnumType', function() {
       const generator = new CodeGenerator();
 
       const albumPrivaciesEnum = new GraphQLEnumType({
@@ -419,7 +419,7 @@ describe('Swift code generation', function() {
       expect(generator.output).toMatchSnapshot();
     });
 
-    it('should generate a struct declaration for a GraphQLInputObjectType', function() {
+    test('should generate a struct declaration for a GraphQLInputObjectType', function() {
       const generator = new CodeGenerator();
 
       typeDeclarationForGraphQLType(generator, schema.getType('ReviewInput'));

--- a/test/swift/language.js
+++ b/test/swift/language.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import { stripIndent } from 'common-tags';
 
 import CodeGenerator from '../../src/utilities/CodeGenerator';
@@ -17,13 +15,13 @@ describe('Swift code generation: Basic language constructs', function() {
     this.generator = new CodeGenerator();
   });
 
-  it(`should generate a class declaration`, function() {
+  test(`should generate a class declaration`, function() {
     classDeclaration(this.generator, { className: 'Hero', modifiers: ['public', 'final'] }, () => {
       propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
       propertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).to.equal(stripIndent`
+    expect(this.generator.output).toBe(stripIndent`
       public final class Hero {
         public let name: String
         public let age: Int
@@ -31,13 +29,13 @@ describe('Swift code generation: Basic language constructs', function() {
     `);
   });
 
-  it(`should generate a struct declaration`, function() {
+  test(`should generate a struct declaration`, function() {
     structDeclaration(this.generator, { structName: 'Hero' }, () => {
       propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
       propertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).to.equal(stripIndent`
+    expect(this.generator.output).toBe(stripIndent`
       public struct Hero {
         public let name: String
         public let age: Int
@@ -45,7 +43,7 @@ describe('Swift code generation: Basic language constructs', function() {
     `);
   });
 
-  it(`should generate nested struct declarations`, function() {
+  test(`should generate nested struct declarations`, function() {
     structDeclaration(this.generator, { structName: 'Hero' }, () => {
       propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
       propertyDeclaration(this.generator, { propertyName: 'friends', typeName: '[Friend]' });
@@ -55,7 +53,7 @@ describe('Swift code generation: Basic language constructs', function() {
       });
     });
 
-    expect(this.generator.output).to.equal(stripIndent`
+    expect(this.generator.output).toBe(stripIndent`
       public struct Hero {
         public let name: String
         public let friends: [Friend]
@@ -67,13 +65,13 @@ describe('Swift code generation: Basic language constructs', function() {
     `);
   });
 
-  it(`should generate a protocol declaration`, function() {
+  test(`should generate a protocol declaration`, function() {
     protocolDeclaration(this.generator, { protocolName: 'HeroDetails', adoptedProtocols: ['HasName'] }, () => {
       protocolPropertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
       protocolPropertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).to.equal(stripIndent`
+    expect(this.generator.output).toBe(stripIndent`
       public protocol HeroDetails: HasName {
         var name: String { get }
         var age: Int { get }

--- a/test/swift/language.js
+++ b/test/swift/language.js
@@ -11,17 +11,19 @@ import {
 } from '../../src/swift/language';
 
 describe('Swift code generation: Basic language constructs', function() {
+  let generator;
+
   beforeEach(function() {
-    this.generator = new CodeGenerator();
+    generator = new CodeGenerator();
   });
 
   test(`should generate a class declaration`, function() {
-    classDeclaration(this.generator, { className: 'Hero', modifiers: ['public', 'final'] }, () => {
-      propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
-      propertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
+    classDeclaration(generator, { className: 'Hero', modifiers: ['public', 'final'] }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String' });
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).toBe(stripIndent`
+    expect(generator.output).toBe(stripIndent`
       public final class Hero {
         public let name: String
         public let age: Int
@@ -30,12 +32,12 @@ describe('Swift code generation: Basic language constructs', function() {
   });
 
   test(`should generate a struct declaration`, function() {
-    structDeclaration(this.generator, { structName: 'Hero' }, () => {
-      propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
-      propertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
+    structDeclaration(generator, { structName: 'Hero' }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String' });
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).toBe(stripIndent`
+    expect(generator.output).toBe(stripIndent`
       public struct Hero {
         public let name: String
         public let age: Int
@@ -44,16 +46,16 @@ describe('Swift code generation: Basic language constructs', function() {
   });
 
   test(`should generate nested struct declarations`, function() {
-    structDeclaration(this.generator, { structName: 'Hero' }, () => {
-      propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
-      propertyDeclaration(this.generator, { propertyName: 'friends', typeName: '[Friend]' });
+    structDeclaration(generator, { structName: 'Hero' }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String' });
+      propertyDeclaration(generator, { propertyName: 'friends', typeName: '[Friend]' });
 
-      structDeclaration(this.generator, { structName: 'Friend' }, () => {
-        propertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
+      structDeclaration(generator, { structName: 'Friend' }, () => {
+        propertyDeclaration(generator, { propertyName: 'name', typeName: 'String' });
       });
     });
 
-    expect(this.generator.output).toBe(stripIndent`
+    expect(generator.output).toBe(stripIndent`
       public struct Hero {
         public let name: String
         public let friends: [Friend]
@@ -66,12 +68,12 @@ describe('Swift code generation: Basic language constructs', function() {
   });
 
   test(`should generate a protocol declaration`, function() {
-    protocolDeclaration(this.generator, { protocolName: 'HeroDetails', adoptedProtocols: ['HasName'] }, () => {
-      protocolPropertyDeclaration(this.generator, { propertyName: 'name', typeName: 'String' });
-      protocolPropertyDeclaration(this.generator, { propertyName: 'age', typeName: 'Int' });
+    protocolDeclaration(generator, { protocolName: 'HeroDetails', adoptedProtocols: ['HasName'] }, () => {
+      protocolPropertyDeclaration(generator, { propertyName: 'name', typeName: 'String' });
+      protocolPropertyDeclaration(generator, { propertyName: 'age', typeName: 'Int' });
     });
 
-    expect(this.generator.output).toBe(stripIndent`
+    expect(generator.output).toBe(stripIndent`
       public protocol HeroDetails: HasName {
         var name: String { get }
         var age: Int { get }

--- a/test/swift/types.js
+++ b/test/swift/types.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import { stripIndent } from 'common-tags'
 
 import {
@@ -22,64 +20,64 @@ import { typeNameFromGraphQLType } from '../../src/swift/types'
 
 describe('Swift code generation: Types', function() {
   describe('#typeNameFromGraphQLType()', function() {
-    it('should return String? for GraphQLString', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLString)).to.equal('String?');
+    test('should return String? for GraphQLString', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLString)).toBe('String?');
     });
 
-    it('should return String for GraphQLNonNull(GraphQLString)', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(GraphQLString))).to.equal('String');
+    test('should return String for GraphQLNonNull(GraphQLString)', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(GraphQLString))).toBe('String');
     });
 
-    it('should return [String?]? for GraphQLList(GraphQLString)', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLList(GraphQLString))).to.equal('[String?]?');
+    test('should return [String?]? for GraphQLList(GraphQLString)', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(GraphQLString))).toBe('[String?]?');
     });
 
-    it('should return [String?] for GraphQLNonNull(GraphQLList(GraphQLString))', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(GraphQLString)))).to.equal('[String?]');
+    test('should return [String?] for GraphQLNonNull(GraphQLList(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(GraphQLString)))).toBe('[String?]');
     });
 
-    it('should return [String]? for GraphQLList(GraphQLNonNull(GraphQLString))', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(GraphQLString)))).to.equal('[String]?');
+    test('should return [String]? for GraphQLList(GraphQLNonNull(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(GraphQLString)))).toBe('[String]?');
     });
 
-    it('should return [String] for GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString)))', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))))).to.equal('[String]');
+    test('should return [String] for GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString)))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))))).toBe('[String]');
     });
 
-    it('should return [[String?]?]? for GraphQLList(GraphQLList(GraphQLString))', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLList(GraphQLString)))).to.equal('[[String?]?]?');
+    test('should return [[String?]?]? for GraphQLList(GraphQLList(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLList(GraphQLString)))).toBe('[[String?]?]?');
     });
 
-    it('should return [[String?]]? for GraphQLList(GraphQLNonNull(GraphQLList(GraphQLString)))', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(new GraphQLList(GraphQLString))))).to.equal('[[String?]]?');
+    test('should return [[String?]]? for GraphQLList(GraphQLNonNull(GraphQLList(GraphQLString)))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(new GraphQLList(GraphQLString))))).toBe('[[String?]]?');
     });
 
-    it('should return Int? for GraphQLInt', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLInt)).to.equal('Int?');
+    test('should return Int? for GraphQLInt', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLInt)).toBe('Int?');
     });
 
-    it('should return Double? for GraphQLFloat', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLFloat)).to.equal('Double?');
+    test('should return Double? for GraphQLFloat', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLFloat)).toBe('Double?');
     });
 
-    it('should return Bool? for GraphQLBoolean', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLBoolean)).to.equal('Bool?');
+    test('should return Bool? for GraphQLBoolean', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLBoolean)).toBe('Bool?');
     });
 
-    it('should return GraphQLID? for GraphQLID', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLID)).to.equal('GraphQLID?');
+    test('should return GraphQLID? for GraphQLID', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLID)).toBe('GraphQLID?');
     });
 
-    it('should return String? for a custom scalar type', function() {
-      expect(typeNameFromGraphQLType({}, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('String?');
+    test('should return String? for a custom scalar type', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('String?');
     });
 
-    it('should return a passed through custom scalar type with the passthroughCustomScalars option', function() {
-      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: '' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('CustomScalarType?');
+    test('should return a passed through custom scalar type with the passthroughCustomScalars option', function() {
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: '' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('CustomScalarType?');
     });
 
-    it('should return a passed through custom scalar type with a prefix with the customScalarsPrefix option', function() {
-      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: 'My' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).to.equal('MyCustomScalarType?');
+    test('should return a passed through custom scalar type with a prefix with the customScalarsPrefix option', function() {
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: 'My' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('MyCustomScalarType?');
     });
   });
 });

--- a/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -1,0 +1,188 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TypeScript code generation #generateSource() should generate correct list with custom fragment 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export interface HeroAndFriendsNamesQueryVariables {
+  episode: Episode | null;
+}
+
+export interface HeroAndFriendsNamesQuery {
+  hero: {
+    // The name of the character
+    name: string,
+    // The friends of the character, or an empty list if they have none
+    friends: Array<FriendFragment>,
+  } | null;
+}
+
+export interface FriendFragment {
+  // The name of the character
+  name: string;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate fragmented query operations 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+export interface HeroAndFriendsNamesQuery {
+  hero: HeroFriendsFragment & {
+    // The name of the character
+    name: string,
+  } | null;
+}
+
+export interface HeroFriendsFragment {
+  // The friends of the character, or an empty list if they have none
+  friends: Array< {
+    // The name of the character
+    name: string,
+  } > | null;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate mutation operations with complex input types 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export interface ReviewInput {
+  // 0-5 stars
+  stars: number;
+  // Comment about the movie, optional
+  commentary: string | null;
+  // Favorite color, optional
+  favorite_color: ColorInput | null;
+}
+
+export interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+export interface ReviewMovieMutationVariables {
+  episode: Episode | null;
+  review: ReviewInput | null;
+}
+
+export interface ReviewMovieMutation {
+  createReview: {
+    // The number of stars this review gave, 1-5
+    stars: number,
+    // Comment about the movie
+    commentary: string | null,
+  } | null;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate query operations with inline fragments 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+export interface HeroAndDetailsQuery {
+  hero: HeroDetailsFragment & {
+    // The name of the character
+    name: string,
+  } | null;
+}
+
+export interface HeroDetailsFragment {
+  // This droid's primary function
+  primaryFunction: string | null;
+  // Height in the preferred unit, default is meters
+  height: number | null;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate simple nested query operations including input variables 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export interface HeroAndFriendsNamesQueryVariables {
+  episode: Episode | null;
+}
+
+export interface HeroAndFriendsNamesQuery {
+  hero: {
+    // The name of the character
+    name: string,
+    // The friends of the character, or an empty list if they have none
+    friends: Array< {
+      // The name of the character
+      name: string,
+    } > | null,
+  } | null;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate simple query operations 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+export interface HeroNameQuery {
+  hero: {
+    // The name of the character
+    name: string,
+  } | null;
+}
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should generate simple query operations including input variables 1`] = `
+"//  This file was automatically generated and should not be edited.
+/* tslint:disable */
+
+// The episodes in the Star Wars trilogy
+export type Episode =
+  \\"NEWHOPE\\" | // Star Wars Episode IV: A New Hope, released in 1977.
+  \\"EMPIRE\\" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  \\"JEDI\\"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
+
+
+export interface HeroNameQueryVariables {
+  episode: Episode | null;
+}
+
+export interface HeroNameQuery {
+  hero: {
+    // The name of the character
+    name: string,
+  } | null;
+}
+/* tslint:enable */
+"
+`;

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -45,7 +45,7 @@ describe('TypeScript code generation', function() {
   });
 
   describe('#generateSource()', function() {
-    it(`should generate simple query operations`, function() {
+    test(`should generate simple query operations`, function() {
       const context = this.compileFromSource(`
         query HeroName {
           hero {
@@ -58,7 +58,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate simple query operations including input variables`, function() {
+    test(`should generate simple query operations including input variables`, function() {
       const context = this.compileFromSource(`
         query HeroName($episode: Episode) {
           hero(episode: $episode) {
@@ -71,7 +71,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate simple nested query operations including input variables`, function() {
+    test(`should generate simple nested query operations including input variables`, function() {
       const context = this.compileFromSource(`
         query HeroAndFriendsNames($episode: Episode) {
           hero(episode: $episode) {
@@ -87,7 +87,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate fragmented query operations`, function() {
+    test(`should generate fragmented query operations`, function() {
       const context = this.compileFromSource(`
         query HeroAndFriendsNames {
           hero {
@@ -107,7 +107,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate query operations with inline fragments`, function() {
+    test(`should generate query operations with inline fragments`, function() {
       const context = this.compileFromSource(`
         query HeroAndDetails {
           hero {
@@ -130,7 +130,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate mutation operations with complex input types`, function() {
+    test(`should generate mutation operations with complex input types`, function() {
       const context = this.compileFromSource(`
         mutation ReviewMovie($episode: Episode, $review: ReviewInput) {
           createReview(episode: $episode, review: $review) {
@@ -144,7 +144,7 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
-    it(`should generate correct list with custom fragment`, function() {
+    test(`should generate correct list with custom fragment`, function() {
       const context = this.compileFromSource(`
         fragment Friend on Character {
           name

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import { stripIndent } from 'common-tags';
 
 import {
@@ -57,18 +55,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        export interface HeroNameQuery {
-          hero: {
-            name: string,
-          } | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate simple query operations including input variables`, function() {
@@ -81,29 +68,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export interface HeroNameQueryVariables {
-          episode: Episode | null;
-        }
-
-        export interface HeroNameQuery {
-          hero: {
-            name: string,
-          } | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate simple nested query operations including input variables`, function() {
@@ -119,32 +84,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export interface HeroAndFriendsNamesQueryVariables {
-          episode: Episode | null;
-        }
-
-        export interface HeroAndFriendsNamesQuery {
-          hero: {
-            name: string,
-            friends: Array< {
-              name: string,
-            } > | null,
-          } | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate fragmented query operations`, function() {
@@ -164,24 +104,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        export interface HeroAndFriendsNamesQuery {
-          hero: HeroFriendsFragment & {
-            name: string,
-          } | null;
-        }
-
-        export interface HeroFriendsFragment {
-          friends: Array< {
-            name: string,
-          } > | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate query operations with inline fragments`, function() {
@@ -204,23 +127,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        export interface HeroAndDetailsQuery {
-          hero: HeroDetailsFragment & {
-            name: string,
-          } | null;
-        }
-
-        export interface HeroDetailsFragment {
-          primaryFunction: string | null;
-          height: number | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate mutation operations with complex input types`, function() {
@@ -234,46 +141,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export interface ReviewInput {
-          // 0-5 stars
-          stars: number;
-          // Comment about the movie, optional
-          commentary: string | null;
-          // Favorite color, optional
-          favorite_color: ColorInput | null;
-        }
-
-        export interface ColorInput {
-          red: number;
-          green: number;
-          blue: number;
-        }
-
-        export interface ReviewMovieMutationVariables {
-          episode: Episode | null;
-          review: ReviewInput | null;
-        }
-
-        export interface ReviewMovieMutation {
-          createReview: {
-            stars: number,
-            commentary: string | null,
-          } | null;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
 
     it(`should generate correct list with custom fragment`, function() {
@@ -293,34 +161,7 @@ describe('TypeScript code generation', function() {
       `);
 
       const source = generateSource(context);
-
-      expect(source).to.include(stripIndent`
-        //  This file was automatically generated and should not be edited.
-        /* tslint:disable */
-
-        // The episodes in the Star Wars trilogy
-        export type Episode =
-          "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
-          "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
-          "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-
-
-        export interface HeroAndFriendsNamesQueryVariables {
-          episode: Episode | null;
-        }
-
-        export interface HeroAndFriendsNamesQuery {
-          hero: {
-            name: string,
-            friends: Array<FriendFragment>,
-          } | null;
-        }
-
-        export interface FriendFragment {
-          name: string;
-        }
-        /* tslint:enable */
-      ` + `\n`);
+      expect(source).toMatchSnapshot();
     });
   });
 });

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -22,6 +22,10 @@ import CodeGenerator from '../../src/utilities/CodeGenerator';
 import { compileToIR } from '../../src/compilation';
 
 describe('TypeScript code generation', function() {
+  let generator;
+  let compileFromSource;
+  let addFragment;
+
   beforeEach(function() {
     const context = {
       schema: schema,
@@ -30,23 +34,23 @@ describe('TypeScript code generation', function() {
       typesUsed: {}
     }
 
-    this.generator = new CodeGenerator(context);
+    generator = new CodeGenerator(context);
 
-    this.compileFromSource = (source) => {
+    compileFromSource = (source) => {
       const document = parse(source);
       const context = compileToIR(schema, document);
-      this.generator.context = context;
+      generator.context = context;
       return context;
     };
 
-    this.addFragment = (fragment) => {
-      this.generator.context.fragments[fragment.fragmentName] = fragment;
+    addFragment = (fragment) => {
+      generator.context.fragments[fragment.fragmentName] = fragment;
     };
   });
 
   describe('#generateSource()', function() {
     test(`should generate simple query operations`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         query HeroName {
           hero {
             name
@@ -59,7 +63,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate simple query operations including input variables`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         query HeroName($episode: Episode) {
           hero(episode: $episode) {
             name
@@ -72,7 +76,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate simple nested query operations including input variables`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         query HeroAndFriendsNames($episode: Episode) {
           hero(episode: $episode) {
             name
@@ -88,7 +92,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate fragmented query operations`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         query HeroAndFriendsNames {
           hero {
             name
@@ -108,7 +112,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate query operations with inline fragments`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         query HeroAndDetails {
           hero {
             name
@@ -131,7 +135,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate mutation operations with complex input types`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         mutation ReviewMovie($episode: Episode, $review: ReviewInput) {
           createReview(episode: $episode, review: $review) {
             stars
@@ -145,7 +149,7 @@ describe('TypeScript code generation', function() {
     });
 
     test(`should generate correct list with custom fragment`, function() {
-      const context = this.compileFromSource(`
+      const context = compileFromSource(`
         fragment Friend on Character {
           name
         }

--- a/test/validation.js
+++ b/test/validation.js
@@ -1,20 +1,19 @@
-import { assert } from 'chai'
+import {assert} from 'chai';
 
-import { readFileSync } from 'fs'
-import path from 'path'
+import {readFileSync} from 'fs';
+import path from 'path';
 
-import {
-  loadSchema,
-  loadAndMergeQueryDocuments,
-} from '../src/loading'
+import {loadSchema, loadAndMergeQueryDocuments} from '../src/loading';
 
-import { validateQueryDocument } from '../src/validation'
+import {validateQueryDocument} from '../src/validation';
 
 const schema = loadSchema(require.resolve('./starwars/schema.json'));
 
 describe('Validation', () => {
   it(`should throw an error for AnonymousQuery.graphql`, () => {
-    const inputPaths = [path.join(__dirname, './starwars/AnonymousQuery.graphql')];
+    const inputPaths = [
+      path.join(__dirname, './starwars/AnonymousQuery.graphql'),
+    ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
     assert.throws(
@@ -24,7 +23,9 @@ describe('Validation', () => {
   });
 
   it(`should throw an error for ExplicitTypename.graphql`, () => {
-    const inputPaths = [path.join(__dirname, './starwars/ExplicitTypename.graphql')];
+    const inputPaths = [
+      path.join(__dirname, './starwars/ExplicitTypename.graphql'),
+    ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
     assert.throws(
@@ -34,7 +35,9 @@ describe('Validation', () => {
   });
 
   it(`should throw an error for TypenameAlias.graphql`, () => {
-    const inputPaths = [path.join(__dirname, './starwars/TypenameAlias.graphql')];
+    const inputPaths = [
+      path.join(__dirname, './starwars/TypenameAlias.graphql'),
+    ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
     assert.throws(

--- a/test/validation.js
+++ b/test/validation.js
@@ -1,5 +1,3 @@
-import {assert} from 'chai';
-
 import {readFileSync} from 'fs';
 import path from 'path';
 
@@ -10,38 +8,41 @@ import {validateQueryDocument} from '../src/validation';
 const schema = loadSchema(require.resolve('./starwars/schema.json'));
 
 describe('Validation', () => {
-  it(`should throw an error for AnonymousQuery.graphql`, () => {
+  test(`should throw an error for AnonymousQuery.graphql`, () => {
     const inputPaths = [
       path.join(__dirname, './starwars/AnonymousQuery.graphql'),
     ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
-    assert.throws(
-      () => validateQueryDocument(schema, document),
+    expect(
+      () => validateQueryDocument(schema, document)
+    ).toThrow(
       'Validation of GraphQL query document failed'
     );
   });
 
-  it(`should throw an error for ExplicitTypename.graphql`, () => {
+  test(`should throw an error for ExplicitTypename.graphql`, () => {
     const inputPaths = [
       path.join(__dirname, './starwars/ExplicitTypename.graphql'),
     ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
-    assert.throws(
-      () => validateQueryDocument(schema, document),
+    expect(
+      () => validateQueryDocument(schema, document)
+    ).toThrow(
       'Validation of GraphQL query document failed'
     );
   });
 
-  it(`should throw an error for TypenameAlias.graphql`, () => {
+  test(`should throw an error for TypenameAlias.graphql`, () => {
     const inputPaths = [
       path.join(__dirname, './starwars/TypenameAlias.graphql'),
     ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
-    assert.throws(
-      () => validateQueryDocument(schema, document),
+    expect(
+      () => validateQueryDocument(schema, document)
+    ).toThrow(
       'Validation of GraphQL query document failed'
     );
   });

--- a/test/valueFromValueNode.js
+++ b/test/valueFromValueNode.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai'
-
 import {
   parseValue,
 } from 'graphql';
@@ -7,66 +5,66 @@ import {
 import { valueFromValueNode }  from '../src/utilities/graphql';
 
 describe('#valueFromValueNode', () => {
-  it(`should return a number for an IntValue`, () => {
+  test(`should return a number for an IntValue`, () => {
     const valueNode = parseValue("1");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal(1);
+    expect(value).toBe(1);
   });
 
-  it(`should return a number for a FloatValue`, () => {
+  test(`should return a number for a FloatValue`, () => {
     const valueNode = parseValue("1.0");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal(1.0);
+    expect(value).toBe(1.0);
   });
 
-  it(`should return a boolean for a BooleanValue`, () => {
+  test(`should return a boolean for a BooleanValue`, () => {
     const valueNode = parseValue("true");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal(true);
+    expect(value).toBe(true);
   });
 
-  it(`should return null for a NullValue`, () => {
+  test(`should return null for a NullValue`, () => {
     const valueNode = parseValue("null");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal(null);
+    expect(value).toBe(null);
   });
 
-  it(`should return a string for a StringValue`, () => {
+  test(`should return a string for a StringValue`, () => {
     const valueNode = parseValue("\"foo\"");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal("foo");
+    expect(value).toBe("foo");
   });
 
-  it(`should return a string for an EnumValue`, () => {
+  test(`should return a string for an EnumValue`, () => {
     const valueNode = parseValue("JEDI");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.equal("JEDI");
+    expect(value).toBe("JEDI");
   });
 
-  it(`should return an object for a Variable`, () => {
+  test(`should return an object for a Variable`, () => {
     const valueNode = parseValue("$something");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.deep.equal({ kind: 'Variable', variableName: 'something' });
+    expect(value).toEqual({ kind: 'Variable', variableName: 'something' });
   });
 
-  it(`should return an array for a ListValue`, () => {
+  test(`should return an array for a ListValue`, () => {
     const valueNode = parseValue("[ \"foo\", 1, JEDI, $something ]");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.deep.equal([ "foo", 1, "JEDI", { kind: 'Variable', variableName: 'something' } ]);
+    expect(value).toEqual([ "foo", 1, "JEDI", { kind: 'Variable', variableName: 'something' } ]);
   });
 
-  it(`should return an object for an ObjectValue`, () => {
+  test(`should return an object for an ObjectValue`, () => {
     const valueNode = parseValue("{ foo: \"foo\", bar: 1, bla: JEDI, baz: $something }");
     const value = valueFromValueNode(valueNode);
 
-    expect(value).to.deep.equal({ foo: "foo", bar: 1, bla: "JEDI", baz: { kind: 'Variable', variableName: 'something' } });
+    expect(value).toEqual({ foo: "foo", bar: 1, bla: "JEDI", baz: { kind: 'Variable', variableName: 'something' } });
   });
 });


### PR DESCRIPTION
Jest snapshots seems perfectly suited for the kinds of assertions apollo-codegen
does in it's tests. Issue described in more detail in #93.

It also has a more intuitive watch mode / interface that's pleasant to use.

Surprisingly after setting up a basic configuration, everything runs out of the box, yay.

- [x] Remove mocha
- [x] Switch configuraton to use Jest
- [x] Get current failing tests passing
- [x] Switch assertions/expectations to snapshots and sanity check to make sure things are correct
- [x] Remove chai
- [x] Use Jest recommended syntax (instead of mocha/jasmine syntax even though its supported currently)