### PR TITLE
Fix incorrect rejection of queries with nested fragments.

### DIFF
--- a/src/compilation.js
+++ b/src/compilation.js
@@ -200,6 +200,9 @@ export class Compiler {
             parentType;
 
           const effectiveType = parentType instanceof GraphQLObjectType ? parentType : inlineFragmentType;
+          if (inlineFragmentType !== effectiveType && !isTypeProperSuperTypeOf(this.schema, inlineFragmentType, effectiveType)) {
+            break;
+          }
 
           this.collectFields(
             effectiveType,

--- a/test/__snapshots__/compilation.js.snap
+++ b/test/__snapshots__/compilation.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Compiling query documents should ignore a fragment's inline fragments whose type conditions do not match more specific effective type 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "args": Array [
+        Object {
+          "name": "id",
+          "value": "human",
+        },
+      ],
+      "fieldName": "human",
+      "fields": Array [],
+      "fragmentSpreads": Array [
+        "CharacterFragment",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "human",
+      "type": "Human",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "name": "id",
+          "value": "droid",
+        },
+      ],
+      "fieldName": "droid",
+      "fields": Array [],
+      "fragmentSpreads": Array [
+        "CharacterFragment",
+      ],
+      "inlineFragments": Array [],
+      "responseName": "droid",
+      "type": "Droid",
+    },
+  ],
+  "fragmentsReferenced": Array [
+    "CharacterFragment",
+  ],
+  "operationName": "HumanAndDroid",
+  "operationType": "query",
+  "variables": Array [],
+}
+`;
+
 exports[`Compiling query documents should include fragment spreads from subselections 1`] = `
 Object {
   "fields": Array [

--- a/test/compilation.js
+++ b/test/compilation.js
@@ -404,6 +404,32 @@ describe('Compiling query documents', () => {
     expect(filteredIR(operations['HeroName'])).toMatchSnapshot();
   });
 
+  test(`should ignore a fragment's inline fragments whose type conditions do not match more specific effective type`, () => {
+    const document = parse(`
+      fragment CharacterFragment on Character {
+        ... on Droid {
+          primaryFunction
+        }
+        ... on Human {
+          height
+        }
+      }
+
+      query HumanAndDroid {
+        human(id: "human") {
+          ...CharacterFragment
+        }
+        droid(id: "droid") {
+          ...CharacterFragment
+        }
+      }
+    `);
+
+    const { operations } = compileToIR(schema, document);
+
+    expect(filteredIR(operations['HumanAndDroid'])).toMatchSnapshot();
+  });
+
   test(`should not inherit type condition when nesting a fragment spread in an inline fragment with a less specific type condition`, () => {
     const document = parse(`
       query HeroName {


### PR DESCRIPTION
When a fragment is defined on a supertype, and it has inline fragments on subtypes, and that fragment is used in a context where the effective type does not match all of those subtypes, the compiler would incorrectly attempt to include fields from all of those spreads, and would fail.

This PR includes a test which crashes at first, and a follow-on commit which fixes the tests.

The following query illustrates the scenario:
```graphql
fragment CharacterFragment on Character {
  ... on Droid {
    primaryFunction
  }
  ... on Human {
    height
  }
}

query HumanAndDroid {
  human(id: "human") {
    ...CharacterFragment
  }
  droid(id: "droid") {
    ...CharacterFragment
  }
}
```

The compiler would previously incorrectly fail with the message:
```
Cannot query field "primaryFunction" on type "Human"
```