### PR TITLE
Handle multiline descriptions in swift

### DIFF
--- a/src/swift/language.js
+++ b/src/swift/language.js
@@ -6,7 +6,7 @@ import {
 function printDescription(generator, description) {
   description && description.split('/n')
     .forEach(line => {
-      generator.printOnNewline(`// ${line.trim()}`);
+      generator.printOnNewline(`/// ${line.trim()}`);
     });
 }
 
@@ -32,8 +32,8 @@ export function structDeclaration(generator, { structName, description, adoptedP
 }
 
 export function propertyDeclaration(generator, { propertyName, typeName, description }) {
-  generator.printOnNewline(`public let ${propertyName}: ${typeName}`);
   printDescription(generator, description);
+  generator.printOnNewline(`public let ${propertyName}: ${typeName}`);
 }
 
 export function propertyDeclarations(generator, properties) {

--- a/src/swift/language.js
+++ b/src/swift/language.js
@@ -3,6 +3,13 @@ import {
   wrap,
 } from '../utilities/printing';
 
+function printDescription(generator, description) {
+  description && description.split('/n')
+    .forEach(line => {
+      generator.printOnNewline(`// ${line.trim()}`);
+    });
+}
+
 export function classDeclaration(generator, { className, modifiers, superClass, adoptedProtocols = [], properties }, closure) {
   generator.printNewlineIfNeeded();
   generator.printNewline();
@@ -16,7 +23,7 @@ export function classDeclaration(generator, { className, modifiers, superClass, 
 
 export function structDeclaration(generator, { structName, description, adoptedProtocols = [] }, closure) {
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(description && `/// ${description}`);
+  printDescription(generator, description);
   generator.printOnNewline(`public struct ${structName}`);
   generator.print(wrap(': ', join(adoptedProtocols, ', ')));
   generator.pushScope({ typeName: structName });
@@ -26,7 +33,7 @@ export function structDeclaration(generator, { structName, description, adoptedP
 
 export function propertyDeclaration(generator, { propertyName, typeName, description }) {
   generator.printOnNewline(`public let ${propertyName}: ${typeName}`);
-  generator.print(description && ` /// ${description}`);
+  printDescription(generator, description);
 }
 
 export function propertyDeclarations(generator, properties) {

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -30,8 +30,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
     public struct CreateReview: GraphQLMappable {
       public let __typename: String
-      public let stars: Int /// The number of stars this review gave, 1-5
-      public let commentary: String? /// Comment about the movie
+      /// The number of stars this review gave, 1-5
+      public let stars: Int
+      /// Comment about the movie
+      public let commentary: String?
 
       public init(reader: GraphQLResultReader) throws {
         __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
@@ -209,7 +211,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
     public struct Hero: GraphQLMappable {
       public let __typename: String
-      public let name: String /// The name of the character
+      /// The name of the character
+      public let name: String
 
       public init(reader: GraphQLResultReader) throws {
         __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
@@ -251,7 +254,8 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public let __typename: String
-  public let name: String /// The name of the character
+  /// The name of the character
+  public let name: String
 
   public let fragments: Fragments
 
@@ -281,8 +285,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public static let possibleTypes = [\\"Droid\\"]
 
   public let __typename: String
-  public let name: String /// What others call this droid
-  public let primaryFunction: String? /// This droid's primary function
+  /// What others call this droid
+  public let name: String
+  /// This droid's primary function
+  public let primaryFunction: String?
 
   public init(reader: GraphQLResultReader) throws {
     __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
@@ -307,8 +313,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public let __typename: String
-  public let name: String /// The name of the character
-  public let friends: [Friend?]? /// The friends of the character, or an empty list if they have none
+  /// The name of the character
+  public let name: String
+  /// The friends of the character, or an empty list if they have none
+  public let friends: [Friend?]?
 
   public init(reader: GraphQLResultReader) throws {
     __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
@@ -318,7 +326,8 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public struct Friend: GraphQLMappable {
     public let __typename: String
-    public let name: String /// The name of the character
+    /// The name of the character
+    public let name: String
 
     public init(reader: GraphQLResultReader) throws {
       __typename = try reader.value(for: Field(responseName: \\"__typename\\"))
@@ -340,8 +349,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public let __typename: String
-  public let name: String /// The name of the character
-  public let appearsIn: [Episode?] /// The movies this character appears in
+  /// The name of the character
+  public let name: String
+  /// The movies this character appears in
+  public let appearsIn: [Episode?]
 
   public init(reader: GraphQLResultReader) throws {
     __typename = try reader.value(for: Field(responseName: \\"__typename\\"))

--- a/test/swift/__snapshots__/language.js.snap
+++ b/test/swift/__snapshots__/language.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Swift code generation: Basic language constructs should handle multi-line descriptions 1`] = `
+"// A hero
+public struct Hero {
+  public let name: String
+  // A multiline comment
+  // on the hero's name.
+}"
+`;

--- a/test/swift/__snapshots__/language.js.snap
+++ b/test/swift/__snapshots__/language.js.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Swift code generation: Basic language constructs should handle multi-line descriptions 1`] = `
-"// A hero
+"/// A hero
 public struct Hero {
+  /// A multiline comment
+  /// on the hero's name.
   public let name: String
-  // A multiline comment
-  // on the hero's name.
+  /// A multiline comment
+  /// on the hero's age.
+  public let age: String
 }"
 `;

--- a/test/swift/language.js
+++ b/test/swift/language.js
@@ -84,6 +84,7 @@ describe('Swift code generation: Basic language constructs', function() {
   test(`should handle multi-line descriptions`, () => {
     structDeclaration(generator, { structName: 'Hero', description: 'A hero' }, () => {
       propertyDeclaration(generator, { propertyName: 'name', typeName: 'String', description: `A multiline comment /n on the hero's name.` });
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'String', description: `A multiline comment /n on the hero's age.` });
     });
 
     expect(generator.output).toMatchSnapshot();

--- a/test/swift/language.js
+++ b/test/swift/language.js
@@ -80,4 +80,12 @@ describe('Swift code generation: Basic language constructs', function() {
       }
     `);
   });
+
+  test(`should handle multi-line descriptions`, () => {
+    structDeclaration(generator, { structName: 'Hero', description: 'A hero' }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String', description: `A multiline comment /n on the hero's name.` });
+    });
+
+    expect(generator.output).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Should address #88 

Split the description by new lines, and print each line of the description as a comment