### PR TITLE
TS: Output `string` not `String` for fallback scalar type.

### DIFF
--- a/src/typescript/types.js
+++ b/src/typescript/types.js
@@ -36,7 +36,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
   if (type instanceof GraphQLList) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: GraphQLString);
+    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: builtInScalarMap[GraphQLString.name]);
   } else {
     typeName = bareTypeName || type.name;
   }


### PR DESCRIPTION
At the moment, apollo-codegen outputs the type `String` as a fallback for custom scalar types (the JS `String` type, very different from TS `string`).

After this patch, it correctly outputs `string`.

If you take a quick look at the patch, I'm fairly certain this was simply unintended behaviour (and lucky that it worked at all), caused by an implicit `toString` on a value of the wrong type.