### PR TITLE
Split on \n as newline character in swift codegen

### DIFF
--- a/src/swift/language.js
+++ b/src/swift/language.js
@@ -4,7 +4,7 @@ import {
 } from '../utilities/printing';
 
 function printDescription(generator, description) {
-  description && description.split('/n')
+  description && description.split('\n')
     .forEach(line => {
       generator.printOnNewline(`/// ${line.trim()}`);
     });

--- a/test/swift/language.js
+++ b/test/swift/language.js
@@ -83,8 +83,8 @@ describe('Swift code generation: Basic language constructs', function() {
 
   test(`should handle multi-line descriptions`, () => {
     structDeclaration(generator, { structName: 'Hero', description: 'A hero' }, () => {
-      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String', description: `A multiline comment /n on the hero's name.` });
-      propertyDeclaration(generator, { propertyName: 'age', typeName: 'String', description: `A multiline comment /n on the hero's age.` });
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String', description: `A multiline comment \n on the hero's name.` });
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'String', description: `A multiline comment \n on the hero's age.` });
     });
 
     expect(generator.output).toMatchSnapshot();


### PR DESCRIPTION
Otherwise, apollo-codegen results in errors where multiline comments are not wrapped correctly.