### PR TITLE
Remove explicit __typename validation for non-Swift targets

### DIFF
--- a/src/compilation.js
+++ b/src/compilation.js
@@ -301,13 +301,11 @@ export class Compiler {
         field.isConditional = true;
       }
 
-      const isIntrospection = parentType.getFields()[fieldName] === undefined;
-      const description = isIntrospection ?
-        null :
-        parentType.getFields()[fieldName].description;
-
-      if (description) {
-        field.description = description
+      // short circuit typenames for now
+      if (fieldName === '__typename') {
+        field.type = `"${parentType}"`
+      } else {
+        field.description = parentType.getFields()[fieldName].description
       }
 
       const bareType = getNamedType(type);

--- a/src/compilation.js
+++ b/src/compilation.js
@@ -93,7 +93,7 @@ export class Compiler {
 
   addTypeUsed(type) {
     if (this.typesUsedSet.has(type)) return;
-    
+
     if (type instanceof GraphQLEnumType ||
         type instanceof GraphQLInputObjectType ||
         (type instanceof GraphQLScalarType && !isBuiltInScalarType(type))) {
@@ -301,7 +301,10 @@ export class Compiler {
         field.isConditional = true;
       }
 
-      const description = parentType.getFields()[fieldName].description;
+      const isIntrospection = parentType.getFields()[fieldName] === undefined;
+      const description = isIntrospection ?
+        null :
+        parentType.getFields()[fieldName].description;
 
       if (description) {
         field.description = description

--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -208,7 +208,13 @@ export function propertyFromField(context, field, forceNullable) {
       isArray, isNullable,
     };
   } else {
-    const typeName = typeNameFromGraphQLType(context, fieldType);
+    // handle __typename
+    let typeName;
+    if (fieldName === '__typename') {
+      typeName = typeNameFromGraphQLType(context, null, fieldType, false);
+    } else {
+      typeName = typeNameFromGraphQLType(context, fieldType);
+    }
     return { ...property, typeName, isComposite: false, fieldType };
   }
 }

--- a/src/flow/types.js
+++ b/src/flow/types.js
@@ -28,7 +28,6 @@ const builtInScalarMap = {
 }
 
 export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = true) {
-  console.log(type);
   if (type instanceof GraphQLNonNull) {
     return typeNameFromGraphQLType(context, type.ofType, bareTypeName, false)
   }

--- a/src/flow/types.js
+++ b/src/flow/types.js
@@ -28,6 +28,7 @@ const builtInScalarMap = {
 }
 
 export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = true) {
+  console.log(type);
   if (type instanceof GraphQLNonNull) {
     return typeNameFromGraphQLType(context, type.ofType, bareTypeName, false)
   }

--- a/src/generate.js
+++ b/src/generate.js
@@ -14,7 +14,7 @@ export default function generate(inputPaths, schemaPath, outputPath, target, opt
 
   const document = loadAndMergeQueryDocuments(inputPaths);
 
-  validateQueryDocument(schema, document);
+  validateQueryDocument(schema, document, target);
 
   const context = compileToIR(schema, document);
   Object.assign(context, options);

--- a/src/validation.js
+++ b/src/validation.js
@@ -6,8 +6,13 @@ import {
 
 import { ToolError, logError } from './errors'
 
-export function validateQueryDocument(schema, document) {
-  const rules = [NoAnonymousQueries, NoExplicitTypename, NoTypenameAlias].concat(specifiedRules);
+export function validateQueryDocument(schema, document, target) {
+  const rules = [
+    NoAnonymousQueries,
+    NoTypenameAlias,
+    ...(target === 'swift' ? [NoExplicitTypename] : []),
+    ...specifiedRules
+  ];
 
   const validationErrors = validate(schema, document, rules);
   if (validationErrors && validationErrors.length > 0) {

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -185,6 +185,7 @@ describe('Flow code generation', function() {
 
         query HeroAndFriendsNames($episode: Episode) {
           hero(episode: $episode) {
+            __typename
             name
             friends {
               ...Friend

--- a/test/validation.js
+++ b/test/validation.js
@@ -21,17 +21,29 @@ describe('Validation', () => {
     );
   });
 
-  test(`should throw an error for ExplicitTypename.graphql`, () => {
+  test(`should throw an error for ExplicitTypename.graphql when the target is Swift`, () => {
     const inputPaths = [
       path.join(__dirname, './starwars/ExplicitTypename.graphql'),
     ];
     const document = loadAndMergeQueryDocuments(inputPaths);
 
     expect(
-      () => validateQueryDocument(schema, document)
+      () => validateQueryDocument(schema, document, 'swift')
     ).toThrow(
       'Validation of GraphQL query document failed'
     );
+  });
+
+  test(`should not throw an error for ExplicitTypename.graphql when the target is not Swift`, () => {
+    const inputPaths = [
+      path.join(__dirname, './starwars/ExplicitTypename.graphql'),
+    ];
+    const document = loadAndMergeQueryDocuments(inputPaths);
+
+    validateQueryDocument(schema, document, 'flow');
+    validateQueryDocument(schema, document, 'typescript');
+    validateQueryDocument(schema, document, 'ts');
+    validateQueryDocument(schema, document, 'json');
   });
 
   test(`should throw an error for TypenameAlias.graphql`, () => {


### PR DESCRIPTION
This allows for explicit `__typename` in queries where we want to use discriminated/disjoint unions (typescript and flow) as discussed in #73. This PR naturally pairs with #86.

Once this and #73 are landed, clients will be able to use the standardized switch based type guard
```
switch (data.__typename) {
  case 'Human':
    // do human stuff
  case 'Droid':
    // do droid stuff
}
```

Or use if/else based type guards

```
if (data.__typename === 'Human') {
  // do human stuff
} else if (data.__typename === 'Droid') {
  // do droid stuff
}
```