### PR TITLE
Add namespacing to JSONDecodable & JSONEncodable extensions in Swift

### DIFF
--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -427,7 +427,7 @@ function enumerationDeclaration(generator, type) {
     );
   });
   generator.printNewline();
-  generator.printOnNewline(`extension ${name}: JSONDecodable, JSONEncodable {}`);
+  generator.printOnNewline(`extension ${name}: Apollo.JSONDecodable, Apollo.JSONEncodable {}`);
 }
 
 function structDeclarationForInputObjectType(generator, type) {

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -519,7 +519,7 @@ exports[`Swift code generation #typeDeclarationForGraphQLType() should escape id
   case \`private\` = \\"PRIVATE\\"
 }
 
-extension AlbumPrivacies: JSONDecodable, JSONEncodable {}"
+extension AlbumPrivacies: Apollo.JSONDecodable, Apollo.JSONEncodable {}"
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate a struct declaration for a GraphQLInputObjectType 1`] = `
@@ -541,5 +541,5 @@ public enum Episode: String {
   case jedi = \\"JEDI\\" /// Star Wars Episode VI: Return of the Jedi, released in 1983.
 }
 
-extension Episode: JSONDecodable, JSONEncodable {}"
+extension Episode: Apollo.JSONDecodable, Apollo.JSONEncodable {}"
 `;


### PR DESCRIPTION
This adds namespacing to the generated `JSONDecodable`and `JSONEncodable` in Swift.
Consumers of the generated code can have identical symbol names, so the generated code should include the package name in the protocol reference.