### PR TITLE
Add filename to error messages printed from CLI

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql';
+import path from 'path';
 
 // ToolError is used for errors that are part of the expected flow
 // and for which a stack trace should not be printed
@@ -42,6 +43,11 @@ export function logErrorMessage(message, fileName, lineNumber) {
       console.log(`error: ${message}`);
     }
   } else {
-    console.log(message);
+    if (fileName) {
+      const truncatedFileName = '/' + fileName.split(path.sep).slice(-4).join(path.sep);
+      console.log(`...${truncatedFileName}: ${message}`);
+    } else {
+      console.log(`error: ${message}`);
+    }
   }
 }


### PR DESCRIPTION
This information exists but isn't exposed in the error messaging. When run on a big project from
CLI -- without the filenames, it's difficult to track down where the errors are being triggered from. Solves #82 

I don't know what the ideal format here is, but I truncated the filename to be the last 4 parts of the file since this worked out well for my use case. There's definitely room for iteration here.

Regarding line numbers -- these weren't correct when coming from javascript source files, but are correct coming from `.graphql` files. I've left the line numbers out for now, since the filename is already a huge improvement -- once you know that it is less difficult to find the source of the validation error once you know the filename.