### PR TITLE
fix(typescript) null check fragmentSpreads and inlineFragments

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -160,13 +160,13 @@ export function typeDeclarationForOperation(
   });
 
   properties.forEach(({ fragmentSpreads, inlineFragments, bareTypeName }) => {
-    if (fragmentSpreads.length > 0) {
+    if (fragmentSpreads && fragmentSpreads.length > 0) {
       fragmentSpreads.forEach(fragmentSpread => {
         fragmentsWithTypenameField[fragmentSpread] = true;
       });
     }
 
-    if (inlineFragments.length > 0) {
+    if (inlineFragments && inlineFragments.length > 0) {
       const fragmentName = `${pascalCase(bareTypeName)}From${operationName}`;
       handleInlineFragments(generator, fragmentName, inlineFragments);
     }

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -168,13 +168,13 @@ export function interfaceDeclarationForOperation(
   });
 
   properties.forEach(({ fragmentSpreads, inlineFragments, bareTypeName }) => {
-    if (fragmentSpreads.length > 0) {
+    if (fragmentSpreads && fragmentSpreads.length > 0) {
       fragmentSpreads.forEach(fragmentSpread => {
         fragmentsWithTypenameField[fragmentSpread] = true;
       });
     }
 
-    if (inlineFragments.length > 0) {
+    if (inlineFragments && inlineFragments.length > 0) {
       const objectName = `${pascalCase(bareTypeName)}From${operationName}`;
       handleInlineFragments(generator, objectName, inlineFragments);
     }


### PR DESCRIPTION
In typescript/codeGeneration.js:

fragmentSpreads and inlineFragments may be null.

This is the case for a query with a simple return type that does not return an object.

Example Query:
```
query basicQuery {
  hello: world
}
```

Example schema:
```
type Query {
  world: String
}
```

I ran into this case when querying for a `currentUserLoginEmail` that returns a string type:
```
query currentUser {
  currentUser {
    id
    contact: contactByContactId {
      id
      firstName
      lastName
    }
  }
  loginEmail: currentUserLoginEmail
}
```