### PR TITLE
Generate Swift operation IDs and operation <--> operation ID mapping file

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "inflected": "^2.0.2",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.5.3",
+    "sjcl": "^1.0.6",
     "source-map-support": "^0.4.15",
     "yargs": "^8.0.1"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -139,7 +139,7 @@ yargs
       },
       "operation-ids-path": {
         demand: false,
-        describe: "Path to a operation-id mapping file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]"
+        describe: "Path to a operation-id mapping file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]",
         default: null,
         normalize: true
       }

--- a/src/cli.js
+++ b/src/cli.js
@@ -136,6 +136,12 @@ yargs
         demand: false,
         describe: "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
         default: 'gql'
+      },
+      "operation-ids-path": {
+        demand: false,
+        describe: "Path to a operation-id mapping file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]"
+        default: null,
+        normalize: true
       }
     },
     argv => {
@@ -155,7 +161,9 @@ yargs
         passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] !== '',
         customScalarsPrefix: argv["custom-scalars-prefix"] || '',
         addTypename: argv["add-typename"],
-        namespace: argv.namespace
+        namespace: argv.namespace,
+        operationIdsPath: argv["operation-ids-path"],
+        generateOperationIds: !!argv["operation-ids-path"]
       };
 
       generate(inputPaths, argv.schema, argv.output, argv.target, argv.tagName, options);

--- a/src/cli.js
+++ b/src/cli.js
@@ -139,7 +139,7 @@ yargs
       },
       "operation-ids-path": {
         demand: false,
-        describe: "Path to a operation-id mapping file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]",
+        describe: "Path to an operation id map file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]",
         default: null,
         normalize: true
       }

--- a/src/cli.js
+++ b/src/cli.js
@@ -139,7 +139,7 @@ yargs
       },
       "operation-ids-path": {
         demand: false,
-        describe: "Path to an operation id map file. If specified, also stores the ids (hashes) as properties on operation types [currently Swift-only]",
+        describe: "Path to an operation id JSON map file. If specified, also stores the operation ids (hashes) as properties on operation types [currently Swift-only]",
         default: null,
         normalize: true
       }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -57,8 +57,18 @@ export default function generate(
     console.log(output);
   }
 
-  if (context.operationIdsPath) {
-    const operationIdsMap = JSON.stringify(context.operationIdsMap, null, 2);
-    fs.writeFileSync(context.operationIdsPath, operationIdsMap);
+  if (context.generateOperationIds) {
+    writeOperationIdsMap(context)
   }
+}
+
+function writeOperationIdsMap(context) {
+  let operationIdsMap = {};
+  Object.values(context.operations).forEach(operation => {
+    operationIdsMap[operation.operationId] = {
+      name: operation.operationName,
+      source: operation.sourceWithFragments  
+    };
+  });
+  fs.writeFileSync(context.operationIdsPath, JSON.stringify(operationIdsMap, null, 2));
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs'
+import * as fs from 'fs';
 
 import { ToolError, logError } from './errors'
 import { loadSchema,  loadAndMergeQueryDocuments } from './loading'
@@ -55,5 +55,10 @@ export default function generate(
     fs.writeFileSync(outputPath, output);
   } else {
     console.log(output);
+  }
+
+  if (context.operationIdsPath) {
+    const operationIdsMap = JSON.stringify(context.operationIdsMap, null, 2);
+    fs.writeFileSync(context.operationIdsPath, operationIdsMap);
   }
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -62,8 +62,13 @@ export default function generate(
   }
 }
 
-function writeOperationIdsMap(context) {
-  let operationIdsMap = {};
+interface OperationIdsMap {
+  name: string,
+  source: string
+}
+
+function writeOperationIdsMap(context: any) {
+  let operationIdsMap: { [id: string]: OperationIdsMap } = {};
   Object.values(context.operations).forEach(operation => {
     operationIdsMap[operation.operationId] = {
       name: operation.operationName,

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -53,6 +53,8 @@ import {
   fieldTypeEnum,
 } from './types';
 
+import * as sjcl from 'sjcl';
+
 import CodeGenerator from '../utilities/CodeGenerator';
 
 export function generateSource(context, options) {
@@ -126,16 +128,16 @@ export function classDeclarationForOperation(
     generator.printNewlineIfNeeded();
 
     // TODO: add check for argument
-    generator.printOnNewline('public static let operationId =');
-    generator.withIndent(() => {
-      const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
-        return fragments.find(fragment => {
-          return fragment.fragmentName == referencedFragmentName;
-        }).source;
-      });
-      sources.unshift(source);
-      multilineString(generator, sources.join('\n'));
+    const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
+      return fragments.find(fragment => {
+        return fragment.fragmentName == referencedFragmentName;
+      }).source;
     });
+    sources.unshift(source);
+    const combinedSource = sources.join('\n');
+    const idBits = sjcl.hash.sha256.hash(combinedSource);
+    const id = sjcl.codec.hex.fromBits(idBits)
+    generator.printOnNewline(`public static let operationId = "${id}"`);
 
     generator.printNewlineIfNeeded();
 

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -401,8 +401,8 @@ function operationId(generator,  { operationName, fragmentsReferenced, source },
   const id = sjcl.codec.hex.fromBits(idBits)
   generator.printOnNewline(`public static let operationId = "${id}"`);
 
-  generator.context.operationIdsMap[operationName] = {
-    id: id
+  generator.context.operationIdsMap[id] = {
+    name: operationName,
     source: combinedSource
   };
 }

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -69,7 +69,7 @@ export function generateSource(context, options) {
     });
 
     Object.values(context.operations).forEach(operation => {
-      classDeclarationForOperation(generator, operation);
+      classDeclarationForOperation(generator, operation, Object.values(context.fragments));
     });
 
     Object.values(context.fragments).forEach(fragment => {
@@ -92,7 +92,8 @@ export function classDeclarationForOperation(
     fragmentSpreads,
     fragmentsReferenced,
     source,
-  }
+  },
+  fragments
 ) {
   let className;
   let protocol;
@@ -121,6 +122,22 @@ export function classDeclarationForOperation(
         multilineString(generator, source);
       });
     }
+
+    generator.printNewlineIfNeeded();
+
+    // TODO: add check for argument
+    generator.printOnNewline('public static let operationId =');
+    generator.withIndent(() => {
+      const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
+        return fragments.find(fragment => {
+          return fragment.fragmentName == referencedFragmentName;
+        }).source;
+      });
+      sources.unshift(source);
+      multilineString(generator, sources.join('\n'));
+    });
+
+    generator.printNewlineIfNeeded();
 
     if (fragmentsReferenced && fragmentsReferenced.length > 0) {
       generator.printOnNewline('public static var requestString: String { return operationString');

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -392,7 +392,7 @@ function operationId(generator,  { operationName, fragmentsReferenced, source },
   generator.printNewlineIfNeeded();
   const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
     return fragments.find(fragment => {
-      return fragment.fragmentName == referencedFragmentName;
+      return fragment.fragmentName === referencedFragmentName;
     }).source;
   });
   sources.unshift(source);

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -127,17 +127,7 @@ export function classDeclarationForOperation(
 
     generator.printNewlineIfNeeded();
 
-    // TODO: add check for argument
-    const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
-      return fragments.find(fragment => {
-        return fragment.fragmentName == referencedFragmentName;
-      }).source;
-    });
-    sources.unshift(source);
-    const combinedSource = sources.join('\n');
-    const idBits = sjcl.hash.sha256.hash(combinedSource);
-    const id = sjcl.codec.hex.fromBits(idBits)
-    generator.printOnNewline(`public static let operationId = "${id}"`);
+    operationId(generator, { fragmentsReferenced, source }, fragments);
 
     generator.printNewlineIfNeeded();
 
@@ -393,6 +383,20 @@ export function structDeclarationForSelectionSet(
       );
     });
   });
+}
+
+function operationId(generator,  { fragmentsReferenced, source }, fragments) {
+  // TODO: add check for argument
+  const sources = fragmentsReferenced.sort().map(referencedFragmentName => {
+    return fragments.find(fragment => {
+      return fragment.fragmentName == referencedFragmentName;
+    }).source;
+  });
+  sources.unshift(source);
+  const combinedSource = sources.join('\n');
+  const idBits = sjcl.hash.sha256.hash(combinedSource);
+  const id = sjcl.codec.hex.fromBits(idBits)
+  generator.printOnNewline(`public static let operationId = "${id}"`);
 }
 
 function propertyDeclarationForField(generator, field) {

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -69,7 +69,7 @@ export function generateSource(context, options) {
     });
 
     Object.values(context.operations).forEach(operation => {
-      classDeclarationForOperation(generator, operation, Object.values(context.fragments));
+      classDeclarationForOperation(generator, operation);
     });
 
     Object.values(context.fragments).forEach(fragment => {
@@ -387,7 +387,7 @@ function operationIdentifier(generator,  { operationName, sourceWithFragments, o
   }
 
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(`public static let operationId = "${operationId}"`);
+  generator.printOnNewline(`public static let operationIdentifier = "${operationId}"`);
 }
 
 function propertyDeclarationForField(generator, field) {

--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -127,7 +127,7 @@ export function classDeclarationForOperation(
       });
     }
 
-    operationId(generator, { fragmentsReferenced, source }, fragments);
+    operationId(generator, { operationName, fragmentsReferenced, source }, fragments);
 
     if (fragmentsReferenced && fragmentsReferenced.length > 0) {
       generator.printNewlineIfNeeded();
@@ -384,7 +384,7 @@ export function structDeclarationForSelectionSet(
   });
 }
 
-function operationId(generator,  { fragmentsReferenced, source }, fragments) {
+function operationId(generator,  { operationName, fragmentsReferenced, source }, fragments) {
   if (!generator.context.generateOperationIds) {
     return
   }
@@ -401,7 +401,10 @@ function operationId(generator,  { fragmentsReferenced, source }, fragments) {
   const id = sjcl.codec.hex.fromBits(idBits)
   generator.printOnNewline(`public static let operationId = "${id}"`);
 
-  generator.context.operationIdsMap[combinedSource] = id
+  generator.context.operationIdsMap[operationName] = {
+    id: id
+    source: combinedSource
+  };
 }
 
 function propertyDeclarationForField(generator, field) {

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -552,7 +552,7 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
     \\"  }\\" +
     \\"}\\"
 
-  public static let operationId = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
+  public static let operationIdentifier = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
   public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -642,6 +642,21 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
 }"
 `;
 
+exports[`Swift code generation #classDeclarationForOperation() when generateOperationIds is specified should generate appropriate operation id mapping source when there are nested fragment references 1`] = `
+"query Hero {
+  hero {
+    ...HeroDetails
+  }
+}
+fragment HeroDetails on Character {
+  ...HeroName
+  appearsIn
+}
+fragment HeroName on Character {
+  name
+}"
+`;
+
 exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for a property 1`] = `
 "public init(episode: Episode) {
   self.episode = episode

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -642,22 +642,6 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
 }"
 `;
 
-exports[`Swift code generation #classDeclarationForOperation() when generateOperationIds is specified should save a mapping from operation id to name and source 1`] = `
-Object {
-  "90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4": Object {
-    "name": "Hero",
-    "source": "query Hero {
-  hero {
-    ...HeroDetails
-  }
-}
-fragment HeroDetails on Character {
-  name
-}",
-  },
-}
-`;
-
 exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for a property 1`] = `
 "public init(episode: Episode) {
   self.episode = episode

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -98,6 +98,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     \\"    }\\" +
     \\"  }\\" +
     \\"}\\"
+
   public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 
   public init() {
@@ -223,6 +224,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     \\"    ...DroidDetails\\" +
     \\"  }\\" +
     \\"}\\"
+
   public static var requestString: String { return operationString.appending(DroidDetails.fragmentString) }
 
   public init() {
@@ -372,6 +374,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     \\"    ...HeroDetails\\" +
     \\"  }\\" +
     \\"}\\"
+
   public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 
   public init() {

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -543,6 +543,121 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 }"
 `;
 
+exports[`Swift code generation #classDeclarationForOperation() when generateOperationIds is specified should generate a class declaration with an operationId property 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+  public static let operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    ...HeroDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  public static let operationId = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
+
+  public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
+
+  public init() {
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes = [\\"Query\\"]
+
+    public static let selections: [Selection] = [
+      Field(\\"hero\\", type: .object(Data.Hero.self)),
+    ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+      self.snapshot = snapshot
+    }
+
+    public init(hero: Hero? = nil) {
+      self.init(snapshot: [\\"__typename\\": \\"Query\\", \\"hero\\": hero])
+    }
+
+    public var hero: Hero? {
+      get {
+        return (snapshot[\\"hero\\"]! as! Snapshot?).flatMap { Hero(snapshot: $0) }
+      }
+      set {
+        snapshot.updateValue(newValue?.snapshot, forKey: \\"hero\\")
+      }
+    }
+
+    public struct Hero: GraphQLSelectionSet {
+      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+      public static let selections: [Selection] = [
+        Field(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]
+
+      public var snapshot: Snapshot
+
+      public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+      }
+
+      public static func makeHuman(name: String) -> Hero {
+        return Hero(snapshot: [\\"__typename\\": \\"Human\\", \\"name\\": name])
+      }
+
+      public static func makeDroid(name: String) -> Hero {
+        return Hero(snapshot: [\\"__typename\\": \\"Droid\\", \\"name\\": name])
+      }
+
+      /// The name of the character
+      public var name: String {
+        get {
+          return snapshot[\\"name\\"]! as! String
+        }
+        set {
+          snapshot.updateValue(newValue, forKey: \\"name\\")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(snapshot: snapshot)
+        }
+        set {
+          snapshot = newValue.snapshot
+        }
+      }
+
+      public struct Fragments {
+        public var snapshot: Snapshot
+
+        public var heroDetails: HeroDetails {
+          get {
+            return HeroDetails(snapshot: snapshot)
+          }
+          set {
+            snapshot = newValue.snapshot
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`Swift code generation #classDeclarationForOperation() when generateOperationIds is specified should save a mapping from operation id to name and source 1`] = `
+Object {
+  "90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4": Object {
+    "name": "Hero",
+    "source": "query Hero {
+  hero {
+    ...HeroDetails
+  }
+}
+fragment HeroDetails on Character {
+  name
+}",
+  },
+}
+`;
+
 exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for a property 1`] = `
 "public init(episode: Episode) {
   self.episode = episode

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -60,7 +60,7 @@ describe('Swift code generation', function() {
 
   describe('#classDeclarationForOperation()', function() {
     test(`should generate a class declaration for a query with variables`, function() {
-      const { operations } = compileFromSource(`
+      const { operations, fragments } = compileFromSource(`
         query HeroName($episode: Episode) {
           hero(episode: $episode) {
             name
@@ -68,12 +68,12 @@ describe('Swift code generation', function() {
         }
       `);
 
-      classDeclarationForOperation(generator, operations['HeroName']);
+      classDeclarationForOperation(generator, operations['HeroName'], Object.values(fragments));
       expect(generator.output).toMatchSnapshot();
     });
 
     test(`should generate a class declaration for a query with fragment spreads`, function() {
-      const { operations } = compileFromSource(`
+      const { operations, fragments } = compileFromSource(`
         query Hero {
           hero {
             ...HeroDetails
@@ -85,12 +85,12 @@ describe('Swift code generation', function() {
         }
       `);
 
-      classDeclarationForOperation(generator, operations['Hero']);
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
       expect(generator.output).toMatchSnapshot();
     });
 
     test(`should generate a class declaration for a query with conditional fragment spreads`, function() {
-      const { operations } = compileFromSource(`
+      const { operations, fragments } = compileFromSource(`
         query Hero {
           hero {
             ...DroidDetails
@@ -102,12 +102,12 @@ describe('Swift code generation', function() {
         }
       `);
 
-      classDeclarationForOperation(generator, operations['Hero']);
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
       expect(generator.output).toMatchSnapshot();
     });
 
     test(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
-      const { operations } = compileFromSource(`
+      const { operations, fragments } = compileFromSource(`
         query Hero {
           hero {
             ... on Droid {
@@ -121,13 +121,13 @@ describe('Swift code generation', function() {
         }
       `);
 
-      classDeclarationForOperation(generator, operations['Hero']);
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
 
       expect(generator.output).toMatchSnapshot();
     });
 
     test(`should generate a class declaration for a mutation with variables`, function() {
-      const { operations } = compileFromSource(`
+      const { operations, fragments } = compileFromSource(`
         mutation CreateReview($episode: Episode) {
           createReview(episode: $episode, review: { stars: 5, commentary: "Wow!" }) {
             stars
@@ -136,7 +136,7 @@ describe('Swift code generation', function() {
         }
       `);
 
-      classDeclarationForOperation(generator, operations['CreateReview']);
+      classDeclarationForOperation(generator, operations['CreateReview'], Object.values(fragments));
 
       expect(generator.output).toMatchSnapshot();
     });

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -264,6 +264,26 @@ describe('Swift code generation', function() {
 
         expect(output1).toBe(output2);
       });
+
+      test(`should generate appropriate operation id mapping source when there are nested fragment references`, function() {
+        const source = `
+          query Hero {
+            hero {
+              ...HeroDetails
+            }
+          }
+          fragment HeroName on Character {
+            name
+          }
+          fragment HeroDetails on Character {
+            ...HeroName
+            appearsIn
+          }
+        `;
+        const context = compileFromSource(source, true);
+        expect(context.operations['Hero'].sourceWithFragments).toMatchSnapshot();
+      });
+
     });
   });
 

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -165,24 +165,6 @@ describe('Swift code generation', function() {
         expect(generator.output).toMatchSnapshot();
       });
 
-      test(`should save a mapping from operation id to name and source`, function() {
-        const source = `
-          query Hero {
-            hero {
-              ...HeroDetails
-            }
-          }
-          fragment HeroDetails on Character {
-            name
-          }
-        `;
-        const context = compileFromSource(source, true);
-
-        classDeclarationForOperation(generator, context.operations['Hero'], Object.values(context.fragments));
-
-        expect(generator.context.operationIdsMap).toMatchSnapshot();
-      });
-
       test(`should generate different operation ids for different operations`, function() {
         const context1 = compileFromSource(`
           query Hero {

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -49,10 +49,10 @@ describe('Swift code generation', function() {
       generator = new CodeGenerator(context);  
     };
 
-    compileFromSource = (source, generateOperationIds = false) => {
+    compileFromSource = (source, options = { generateOperationIds: false }) => {
       const document = parse(source);
       let context = compileToIR(schema, document);
-      generateOperationIds && Object.assign(context, { generateOperationIds: true, operationIdsMap: {} });
+      options.generateOperationIds && Object.assign(context, { generateOperationIds: true, operationIdsMap: {} });
       generator.context = context;
       return context;
     };
@@ -148,6 +148,7 @@ describe('Swift code generation', function() {
     });
 
     describe(`when generateOperationIds is specified`, function() {
+      let compileOptions = { generateOperationIds: true };
 
       test(`should generate a class declaration with an operationId property`, function() {
         const context = compileFromSource(`
@@ -159,7 +160,7 @@ describe('Swift code generation', function() {
           fragment HeroDetails on Character {
             name
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context.operations['Hero'], Object.values(context.fragments));
         expect(generator.output).toMatchSnapshot();
@@ -175,7 +176,7 @@ describe('Swift code generation', function() {
           fragment HeroDetails on Character {
             name
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context1.operations['Hero'], Object.values(context1.fragments));
         const output1 = generator.output;
@@ -190,7 +191,7 @@ describe('Swift code generation', function() {
           fragment HeroDetails on Character {
             appearsIn
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context2.operations['Hero'], Object.values(context2.fragments));
         const output2 = generator.output;
@@ -205,7 +206,7 @@ describe('Swift code generation', function() {
               name
             }
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context1.operations['HeroName'], Object.values(context1.fragments));
         const output1 = generator.output;
@@ -215,7 +216,7 @@ describe('Swift code generation', function() {
           # Profound comment
           query HeroName($episode:Episode) { hero(episode: $episode) { name } }
           # Deeply meaningful comment
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context2.operations['HeroName'], Object.values(context2.fragments));
         const output2 = generator.output;
@@ -237,7 +238,7 @@ describe('Swift code generation', function() {
           fragment HeroAppearsIn on Character {
             appearsIn
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context1.operations['Hero'], Object.values(context1.fragments));
         const output1 = generator.output;
@@ -256,7 +257,7 @@ describe('Swift code generation', function() {
           fragment HeroName on Character {
             name
           }
-        `, true);
+        `, compileOptions);
 
         classDeclarationForOperation(generator, context2.operations['Hero'], Object.values(context2.fragments));
         const output2 = generator.output;


### PR DESCRIPTION
This introduces - to Swift only - the notion of `operationId`s, which are unique identifiers for operations. The primary use for these ids is registration with a server, to do query persistence and whitelisting.

The operation id is generated by concatenating the formatting-normalized source of the operation with the formatting-normalized sorted sources of the fragments it references. It's a whitespace-agnostic "fingerprint" of the operation source that's sent to the server. Note, however, that it is *not* agnostic to field order.

When the `operation-ids-path` option is provided to `apollo-codegen`, the following occurs:
* An `operationId` static property is added to the operation class definition.
* The operation id and concatenated operation/fragment source blob are added to a map file.

The updated operation class definitions looks like:
```swift
public final class HeroAndFriendsQuery: GraphQLQuery {
  public static let operationString =
    "query HeroAndFriends($episode: Episode) {" +
    "  hero(episode: $episode) {" +
    "    __typename" +
    "    ...heroDetails" +
    "  }" +
    "}"

  public static let operationId = "6fecbcfcc753ec6f3f75c935270adeb5a7767397d783f7a747021cc86a9d59b7"
 
  // ...
}
```

The generated map file looks like:
```json
{
  "6fecbcfcc753ec6f3f75c935270adeb5a7767397d783f7a747021cc86a9d59b7": {
    "name": "HeroAndFriends",
    "source": "query HeroAndFriends($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...heroDetails\n  }\n}\nfragment heroDetails on Character {\n  __typename\n  name\n  ... on Droid {\n    __typename\n    primaryFunction\n  }\n  ... on Human {\n    __typename\n    height\n  }\n}"
  },
  "fe3f21394eb861aa515c4d582e645469045793c9cbbeca4b5d4ce4d7dd617556": {
    "name": "HeroAndFriendsNames",
    "source": "query HeroAndFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"
  },
  "bfaf75d346817b596a648fe6577f2068cdf95b7118cbed245f79720e82fafa9e": {
    "name": "HeroAppearsIn",
    "source": "query HeroAppearsIn {\n  hero {\n    __typename\n    name\n    appearsIn\n  }\n}"
  },
  "08f9b4c5c02d0f28f2fb9409286362f394b2195aeffd6ded783b9f6dcce7dd6f": {
    "name": "HeroName",
    "source": "query HeroName {\n  hero {\n    __typename\n    name\n  }\n}"
  },
  "b868fa9c48f19b8151c08c09f46831e3b9cd09f5c617d328647de785244b52bb": {
    "name": "TwoHeroes",
    "source": "query TwoHeroes {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    name\n  }\n}"
  }
}
```

## Why not use [persistgraphql](https://github.com/apollographql/persistgraphql)?
* I didn't want to introduce a dependency, and the approach taken seemed simpler
* A lot of what `persistgraphql` concerns itself with is parsing and extraction, which `apollo-codegen` doesn't need (since it already does)
* `persistgraphql` assigns an incrementing id to each operation; we want more of a unique "fingerprint"

## Remaining work
- [ ] Discuss & refine
- [x] Verify in `apollo-ios` repo (generate new `API.swift` with operation ids and verify all unit tests pass)
- [x] Add unit tests