### PR TITLE
Support multiline comments for Flow/Typescript targets

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -66,7 +66,12 @@ function enumerationDeclaration(generator, type) {
   const values = type.getValues();
 
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
   generator.printOnNewline(`export type ${name} =`);
   const nValues = values.length;
   values.forEach((value, i) =>

--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -35,7 +35,12 @@ export function propertyDeclaration(generator, {
 }, closure, open = ' {|', close = '|}') {
   const name = fieldName || propertyName;
 
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
 
   if (closure) {
     generator.printOnNewline(`${name}:`);
@@ -69,7 +74,12 @@ export function propertySetsDeclaration(generator, property, propertySets, stand
   const { description, fieldName, propertyName, typeName, isNullable, isArray } = property;
   const name = fieldName || propertyName;
 
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
   if (!standalone) {
     generator.printOnNewline(`${name}:`);
   }

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -70,7 +70,12 @@ function enumerationDeclaration(generator, type) {
   const values = type.getValues();
 
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
   generator.printOnNewline(`export type ${name} =`);
   const nValues = values.length;
   values.forEach((value, i) => 

--- a/src/typescript/language.js
+++ b/src/typescript/language.js
@@ -35,7 +35,12 @@ export function propertyDeclaration(generator, {
 }, closure) {
   const name = fieldName || propertyName;
 
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
 
   if (closure) {
     generator.printOnNewline(`${name}: `);
@@ -66,7 +71,13 @@ export function propertySetsDeclaration(generator, property, propertySets, stand
   const { description, fieldName, propertyName, typeName, isNullable, isArray } = property;
   const name = fieldName || propertyName;
 
-  generator.printOnNewline(description && `// ${description}`);
+  if (description) {
+    description.split('\n')
+      .forEach(line => {
+        generator.printOnNewline(`// ${line.trim()}`);
+      })
+  }
+
   if (!standalone) {
     generator.printOnNewline(`${name}: `);
   }

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -388,3 +388,30 @@ export type HeroNameQuery = {|
   ),
 |};"
 `;
+
+exports[`Flow code generation #generateSource() should handle multi-line comments 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type CustomScalarQuery = {|
+  commentTest: ? {|
+    __typename: string,
+    // This is a multi-line
+    // comment.
+    multiLine: ?string,
+  |},
+|};"
+`;
+
+exports[`Flow code generation #generateSource() should handle single line comments 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type CustomScalarQuery = {|
+  commentTest: ? {|
+    __typename: string,
+    // This is a single-line comment
+    singleLine: ?string,
+  |},
+|};"
+`;

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -211,5 +211,33 @@ describe('Flow code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should handle single line comments', () => {
+      const { compileFromSource } = setup(miscSchema);
+      const context = compileFromSource(`
+        query CustomScalar {
+          commentTest {
+            singleLine
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
+    test('should handle multi-line comments', () => {
+      const { compileFromSource } = setup(miscSchema);
+      const context = compileFromSource(`
+        query CustomScalar {
+          commentTest {
+            multiLine
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });

--- a/test/misc/schema.graphql
+++ b/test/misc/schema.graphql
@@ -14,6 +14,17 @@ type OddType {
   camel: doubleHump
 }
 
+# This is a type to test comments
+type CommentTest {
+  # This is a single-line comment
+  singleLine: String
+  # This is a multi-line
+  # comment.
+  multiLine: String
+}
+
 type Query {
   misc: OddType
+  commentTest: CommentTest
 }
+

--- a/test/misc/schema.json
+++ b/test/misc/schema.json
@@ -23,6 +23,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "commentTest",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentTest",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -117,6 +129,41 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CommentTest",
+          "description": "This is a type to test comments",
+          "fields": [
+            {
+              "name": "singleLine",
+              "description": "This is a single-line comment",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multiLine",
+              "description": "This is a multi-line\ncomment.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -317,3 +317,34 @@ export type HeroNameQuery = {
 /* tslint:enable */
 "
 `;
+
+exports[`TypeScript code generation #generateSource() should handle multi-line comments 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type CustomScalarQuery = {
+  commentTest:  {
+    __typename: string,
+    // This is a multi-line
+    // comment.
+    multiLine: string | null,
+  } | null,
+};
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should handle single line comments 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type CustomScalarQuery = {
+  commentTest:  {
+    __typename: string,
+    // This is a single-line comment
+    singleLine: string | null,
+  } | null,
+};
+/* tslint:enable */
+"
+`;


### PR DESCRIPTION
fixes #117

This fix was made to the Swift target previously but was not made for Flow/Typescript targets.
Tests were also added to ensure the simplest case works.