### PR TITLE
Optional Flow Inputs

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -222,11 +222,11 @@ export function typeDeclarationForFragment(
   });
 }
 
-export function propertiesFromFields(context, fields, forceNullable) {
-  return fields.map(field => propertyFromField(context, field, forceNullable));
+export function propertiesFromFields(context, fields) {
+  return fields.map(field => propertyFromField(context, field));
 }
 
-export function propertyFromField(context, field, forceNullable) {
+export function propertyFromField(context, field) {
   let { name: fieldName, type: fieldType, description, fragmentSpreads, inlineFragments } = field;
   fieldName = fieldName || field.responseName;
 
@@ -244,7 +244,7 @@ export function propertyFromField(context, field, forceNullable) {
       isArray = true;
     }
     let isNullable = true;
-    if (fieldType instanceof GraphQLNonNull && !forceNullable) {
+    if (fieldType instanceof GraphQLNonNull) {
       isNullable = false;
     }
     return {

--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -89,7 +89,7 @@ function structDeclarationForInputObjectType(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
@@ -129,7 +129,7 @@ export function interfaceVariablesDeclarationForOperation(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, variables);
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
@@ -150,13 +150,13 @@ export function typeDeclarationForOperation(
   typeDeclaration(generator, {
     interfaceName,
   }, () => {
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
 export function typeDeclarationForFragment(
   generator,
-  fragment 
+  fragment
 ) {
   const {
     fragmentName,
@@ -217,7 +217,7 @@ export function typeDeclarationForFragment(
       propertySetsDeclaration(generator, fragment, propertySets, true);
     } else {
       const properties = propertiesFromFields(generator.context, fields)
-      propertyDeclarations(generator, properties, true);
+      propertyDeclarations(generator, properties);
     }
   });
 }
@@ -263,7 +263,7 @@ export function propertyFromField(context, field, forceNullable) {
   }
 }
 
-export function propertyDeclarations(generator, properties, inInterface) {
+export function propertyDeclarations(generator, properties) {
   if (!properties) return;
   properties.forEach(property => {
     if (isAbstractType(getNamedType(property.type || property.fieldType))) {
@@ -316,7 +316,7 @@ export function propertyDeclarations(generator, properties, inInterface) {
           propertyDeclarations(generator, properties);
         });
       } else {
-        propertyDeclaration(generator, {...property, inInterface});
+        propertyDeclaration(generator, property);
       }
     }
   });

--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -30,7 +30,6 @@ export function propertyDeclaration(generator, {
   description,
   isArray,
   isNullable,
-  inInterface,
   fragmentSpreads
 }, closure, open = ' {|', close = '|}') {
   const name = fieldName || propertyName;

--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -30,7 +30,8 @@ export function propertyDeclaration(generator, {
   description,
   isArray,
   isNullable,
-  fragmentSpreads
+  fragmentSpreads,
+  isInput
 }, closure, open = ' {|', close = '|}') {
   const name = fieldName || propertyName;
 
@@ -42,7 +43,11 @@ export function propertyDeclaration(generator, {
   }
 
   if (closure) {
-    generator.printOnNewline(`${name}:`);
+    generator.printOnNewline(name)
+    if (isInput && isNullable) {
+      generator.print('?')
+    }
+    generator.print(':')
     if (isNullable) {
       generator.print(' ?');
     }
@@ -64,7 +69,11 @@ export function propertyDeclaration(generator, {
     }
 
   } else {
-    generator.printOnNewline(`${name}: ${typeName || typeNameFromGraphQLType(generator.context, type)}`);
+    generator.printOnNewline(name)
+    if (isInput && isNullable) {
+      generator.print('?')
+    }
+    generator.print(`: ${typeName || typeNameFromGraphQLType(generator.context, type)}`);
   }
   generator.print(',');
 }

--- a/src/flow/types.js
+++ b/src/flow/types.js
@@ -34,7 +34,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
 
   let typeName;
   if (type instanceof GraphQLList) {
-    typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
+    typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName)} >`;
   } else if (type instanceof GraphQLScalarType) {
     typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name : 'any');
   } else {

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -226,11 +226,11 @@ export function interfaceDeclarationForFragment(
   });
 }
 
-export function propertiesFromFields(context, fields, forceNullable) {
-  return fields.map(field => propertyFromField(context, field, forceNullable));
+export function propertiesFromFields(context, fields) {
+  return fields.map(field => propertyFromField(context, field));
 }
 
-export function propertyFromField(context, field, forceNullable) {
+export function propertyFromField(context, field) {
   let { name: fieldName, type: fieldType, description, fragmentSpreads, inlineFragments } = field;
   fieldName = fieldName || field.responseName;
 
@@ -249,7 +249,7 @@ export function propertyFromField(context, field, forceNullable) {
       isArray = true
     }
     let isNullable = true;
-    if (fieldType instanceof GraphQLNonNull && !forceNullable) {
+    if (fieldType instanceof GraphQLNonNull) {
       isNullable = false;
     }
     return {

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -36,7 +36,7 @@ import {
 
 export function generateSource(context) {
   const generator = new CodeGenerator(context);
-  
+
   generator.printOnNewline('/* tslint:disable */');
   generator.printOnNewline('//  This file was automatically generated and should not be edited.');
 
@@ -78,7 +78,7 @@ function enumerationDeclaration(generator, type) {
   }
   generator.printOnNewline(`export type ${name} =`);
   const nValues = values.length;
-  values.forEach((value, i) => 
+  values.forEach((value, i) =>
     generator.printOnNewline(`  "${value.value}"${i === nValues-1 ? ';' : ' |'}${wrap(' // ', value.description)}`)
   );
   generator.printNewline();
@@ -93,7 +93,7 @@ function structDeclarationForInputObjectType(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
@@ -133,7 +133,7 @@ export function interfaceVariablesDeclarationForOperation(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, variables);
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
@@ -154,7 +154,7 @@ export function interfaceDeclarationForOperation(
   interfaceDeclaration(generator, {
     interfaceName,
   }, () => {
-    propertyDeclarations(generator, properties, true);
+    propertyDeclarations(generator, properties);
   });
 }
 
@@ -221,7 +221,7 @@ export function interfaceDeclarationForFragment(
       propertySetsDeclaration(generator, fragment, propertySets, true);
     } else {
       const properties = propertiesFromFields(generator.context, fields)
-      propertyDeclarations(generator, properties, true);
+      propertyDeclarations(generator, properties);
     }
   });
 }
@@ -268,7 +268,7 @@ export function propertyFromField(context, field, forceNullable) {
   }
 }
 
-export function propertyDeclarations(generator, properties, inInterface) {
+export function propertyDeclarations(generator, properties) {
   if (!properties) return;
   properties.forEach(property => {
     if (isAbstractType(getNamedType(property.type || property.fieldType))) {
@@ -321,7 +321,7 @@ export function propertyDeclarations(generator, properties, inInterface) {
           propertyDeclarations(generator, properties);
         });
       } else {
-        propertyDeclaration(generator, {...property, inInterface});
+        propertyDeclaration(generator, property);
       }
     }
   });

--- a/src/typescript/language.js
+++ b/src/typescript/language.js
@@ -30,7 +30,6 @@ export function propertyDeclaration(generator, {
   description,
   isArray,
   isNullable,
-  inInterface,
   fragmentSpreads
 }, closure) {
   const name = fieldName || propertyName;
@@ -48,19 +47,19 @@ export function propertyDeclaration(generator, {
       generator.print(' Array<');
     }
     generator.pushScope({ typeName: name });
-  
+
     generator.withinBlock(closure);
-  
+
     generator.popScope();
-  
+
     if (isArray) {
       generator.print(' >');
     }
-  
+
     if (isNullable) {
       generator.print(' | null');
     }
-  
+
   } else {
     generator.printOnNewline(`${name}: ${typeName || typeNameFromGraphQLType(generator.context, type)}`);
   }

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -24,7 +24,7 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode: ?Episode,
+  episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
@@ -97,7 +97,7 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode: ?Episode,
+  episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
@@ -231,9 +231,9 @@ export type ReviewInput = {|
   // 0-5 stars
   stars: number,
   // Comment about the movie, optional
-  commentary: ?string,
+  commentary?: ?string,
   // Favorite color, optional
-  favorite_color: ?ColorInput,
+  favorite_color?: ?ColorInput,
 |};
 
 export type ColorInput = {|
@@ -243,8 +243,8 @@ export type ColorInput = {|
 |};
 
 export type ReviewMovieMutationVariables = {|
-  episode: ?Episode,
-  review: ?ReviewInput,
+  episode?: ?Episode,
+  review?: ?ReviewInput,
 |};
 
 export type ReviewMovieMutation = {|
@@ -303,7 +303,7 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode: ?Episode,
+  episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
@@ -372,7 +372,7 @@ export type Episode =
 
 
 export type HeroNameQueryVariables = {|
-  episode: ?Episode,
+  episode?: ?Episode,
 |};
 
 export type HeroNameQuery = {|


### PR DESCRIPTION
Removes some unused variables (`inInterface`, `forceNullable`) and adds an explicit `isNullable` property which is passed down to all property declarations, as well as an `isInput` property which is used to mark that the property should be optional in the type definition if it's nullable, as pointed out in #134. Will open a similar PR in TS to address #81.