### PR TITLE
Fix missed toggling of input types in typescript target

### DIFF
--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -93,7 +93,7 @@ function structDeclarationForInputObjectType(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, Object.values(type.getFields()));
-    propertyDeclarations(generator, properties);
+    propertyDeclarations(generator, properties, true);
   });
 }
 
@@ -133,7 +133,7 @@ export function interfaceVariablesDeclarationForOperation(
     interfaceName,
   }, () => {
     const properties = propertiesFromFields(generator.context, variables);
-    propertyDeclarations(generator, properties);
+    propertyDeclarations(generator, properties, true);
   });
 }
 


### PR DESCRIPTION
These changes were supposed to get in #156 when migrating over
from Flow it looks like, but they aren't there.