### PR TITLE
Make generated flow types immutable using covariant properties (#129) and $ReadOnlyArray (#135)

### DIFF
--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -43,7 +43,7 @@ export function propertyDeclaration(generator, {
   }
 
   if (closure) {
-    generator.printOnNewline(name)
+    generator.printOnNewline(`+${name}`)
     if (isInput && isNullable) {
       generator.print('?')
     }
@@ -69,7 +69,7 @@ export function propertyDeclaration(generator, {
     }
 
   } else {
-    generator.printOnNewline(name)
+    generator.printOnNewline(`+${name}`)
     if (isInput && isNullable) {
       generator.print('?')
     }
@@ -89,7 +89,7 @@ export function propertySetsDeclaration(generator, property, propertySets, stand
       })
   }
   if (!standalone) {
-    generator.printOnNewline(`${name}:`);
+    generator.printOnNewline(`+${name}:`);
   }
 
   if (isNullable) {

--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -55,7 +55,7 @@ export function propertyDeclaration(generator, {
       if (!isNullable) {
         generator.print(' ');
       }
-      generator.print(' Array<');
+      generator.print(' $ReadOnlyArray<');
     }
 
     generator.pushScope({ typeName: name });
@@ -97,7 +97,7 @@ export function propertySetsDeclaration(generator, property, propertySets, stand
   }
 
   if (isArray) {
-    generator.print('Array< ');
+    generator.print('$ReadOnlyArray< ');
   }
 
   generator.pushScope({ typeName: name });

--- a/src/flow/types.js
+++ b/src/flow/types.js
@@ -34,7 +34,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
 
   let typeName;
   if (type instanceof GraphQLList) {
-    typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName)} >`;
+    typeName = `$ReadOnlyArray< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName)} >`;
   } else if (type instanceof GraphQLScalarType) {
     typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name : 'any');
   } else {

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -5,9 +5,9 @@ exports[`Flow code generation #generateSource() should annotate custom scalars a
 //  This file was automatically generated and should not be edited.
 
 export type CustomScalarQuery = {|
-  misc: ? {|
-    __typename: string,
-    date: ?any,
+  +misc: ? {|
+    +__typename: string,
+    +date: ?any,
   |},
 |};"
 `;
@@ -24,38 +24,38 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode?: ?Episode,
+  +episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     }
@@ -63,24 +63,24 @@ export type HeroAndFriendsNamesQuery = {|
 |};
 
 export type FriendFragment = ( {
-      __typename: \\"Human\\",
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
     }
   );
 
 export type PersonFragment = ( {
-      __typename: \\"Human\\",
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
     }
   );"
 `;
@@ -97,38 +97,38 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode?: ?Episode,
+  +episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     }
@@ -136,13 +136,13 @@ export type HeroAndFriendsNamesQuery = {|
 |};
 
 export type FriendFragment = ( {
-      __typename: \\"Human\\",
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
     }
   );"
 `;
@@ -152,34 +152,34 @@ exports[`Flow code generation #generateSource() should generate fragmented query
 //  This file was automatically generated and should not be edited.
 
 export type HeroAndFriendsNamesQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     }
@@ -187,29 +187,29 @@ export type HeroAndFriendsNamesQuery = {|
 |};
 
 export type HeroFriendsFragment = ( {
-      __typename: \\"Human\\",
+      +__typename: \\"Human\\",
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     }
@@ -229,31 +229,31 @@ export type Episode =
 
 export type ReviewInput = {|
   // 0-5 stars
-  stars: number,
+  +stars: number,
   // Comment about the movie, optional
-  commentary?: ?string,
+  +commentary?: ?string,
   // Favorite color, optional
-  favorite_color?: ?ColorInput,
+  +favorite_color?: ?ColorInput,
 |};
 
 export type ColorInput = {|
-  red: number,
-  green: number,
-  blue: number,
+  +red: number,
+  +green: number,
+  +blue: number,
 |};
 
 export type ReviewMovieMutationVariables = {|
-  episode?: ?Episode,
-  review?: ?ReviewInput,
+  +episode?: ?Episode,
+  +review?: ?ReviewInput,
 |};
 
 export type ReviewMovieMutation = {|
-  createReview: ? {|
-    __typename: string,
+  +createReview: ? {|
+    +__typename: string,
     // The number of stars this review gave, 1-5
-    stars: number,
+    +stars: number,
     // Comment about the movie
-    commentary: ?string,
+    +commentary: ?string,
   |},
 |};"
 `;
@@ -263,30 +263,30 @@ exports[`Flow code generation #generateSource() should generate query operations
 //  This file was automatically generated and should not be edited.
 
 export type HeroAndDetailsQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // What this human calls themselves
-      name: string,
+      +name: string,
       // Height in the preferred unit, default is meters
-      height: ?number,
+      +height: ?number,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // What others call this droid
-      name: string,
+      +name: string,
       // This droid's primary function
-      primaryFunction: ?string,
+      +primaryFunction: ?string,
     }
   ),
 |};
 
 export type HeroDetailsFragment = ( {
-      __typename: \\"Human\\",
+      +__typename: \\"Human\\",
       // Height in the preferred unit, default is meters
-      height: ?number,
+      +height: ?number,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // This droid's primary function
-      primaryFunction: ?string,
+      +primaryFunction: ?string,
     }
   );"
 `;
@@ -303,38 +303,38 @@ export type Episode =
 
 
 export type HeroAndFriendsNamesQueryVariables = {|
-  episode?: ?Episode,
+  +episode?: ?Episode,
 |};
 
 export type HeroAndFriendsNamesQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
       // The friends of the character, or an empty list if they have none
-      friends: ?Array< ( {
-          __typename: \\"Human\\",
+      +friends: ?Array< ( {
+          +__typename: \\"Human\\",
           // The name of the character
-          name: string,
+          +name: string,
         } | {
-          __typename: \\"Droid\\",
+          +__typename: \\"Droid\\",
           // The name of the character
-          name: string,
+          +name: string,
         }
       ) >,
     }
@@ -347,14 +347,14 @@ exports[`Flow code generation #generateSource() should generate simple query ope
 //  This file was automatically generated and should not be edited.
 
 export type HeroNameQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
     }
   ),
 |};"
@@ -372,18 +372,18 @@ export type Episode =
 
 
 export type HeroNameQueryVariables = {|
-  episode?: ?Episode,
+  +episode?: ?Episode,
 |};
 
 export type HeroNameQuery = {|
-  hero: ?( {
-      __typename: \\"Human\\",
+  +hero: ?( {
+      +__typename: \\"Human\\",
       // The name of the character
-      name: string,
+      +name: string,
     } | {
-      __typename: \\"Droid\\",
+      +__typename: \\"Droid\\",
       // The name of the character
-      name: string,
+      +name: string,
     }
   ),
 |};"
@@ -394,11 +394,11 @@ exports[`Flow code generation #generateSource() should handle multi-line comment
 //  This file was automatically generated and should not be edited.
 
 export type CustomScalarQuery = {|
-  commentTest: ? {|
-    __typename: string,
+  +commentTest: ? {|
+    +__typename: string,
     // This is a multi-line
     // comment.
-    multiLine: ?string,
+    +multiLine: ?string,
   |},
 |};"
 `;
@@ -408,10 +408,10 @@ exports[`Flow code generation #generateSource() should handle single line commen
 //  This file was automatically generated and should not be edited.
 
 export type CustomScalarQuery = {|
-  commentTest: ? {|
-    __typename: string,
+  +commentTest: ? {|
+    +__typename: string,
     // This is a single-line comment
-    singleLine: ?string,
+    +singleLine: ?string,
   |},
 |};"
 `;

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -33,7 +33,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -48,7 +48,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -106,7 +106,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -121,7 +121,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -157,7 +157,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -172,7 +172,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -189,7 +189,7 @@ export type HeroAndFriendsNamesQuery = {|
 export type HeroFriendsFragment = ( {
       +__typename: \\"Human\\",
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -202,7 +202,7 @@ export type HeroFriendsFragment = ( {
     } | {
       +__typename: \\"Droid\\",
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -312,7 +312,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,
@@ -327,7 +327,7 @@ export type HeroAndFriendsNamesQuery = {|
       // The name of the character
       +name: string,
       // The friends of the character, or an empty list if they have none
-      +friends: ?Array< ( {
+      +friends: ?$ReadOnlyArray< ( {
           +__typename: \\"Human\\",
           // The name of the character
           +name: string,


### PR DESCRIPTION
Hey,

I created this pull request to push to idea further to make the created flow types immutable. In both issues #129 and #135 @rricard said he would welcome pull request. This is not necessarily to be merged but to give an outlook how the result could look like. Unfortunately I don't have a big code base that uses apollo-codegen to test how this would affect a bigger project in practise.

These changes make covariant fields and read only arrays the *only default*. This might not be the wanted behaviour.

This is my fist PR, I would love to get some feedback and work further on this. I can also separate the commits in two PRs.

Example query `test/starwars/HeroAndFriendsNames.graphql`:
```graphql
query HeroAndFriendsNames($episode: Episode) {
  hero(episode: $episode) {
    name
    friends {
      name
    }
  }
}
```

Output (I removed the comments to highlight the changes):
```javascript
// before
export type Episode = "NEWHOPE" | "EMPIRE" | "JEDI";

export type HeroAndFriendsNamesQueryVariables = {|
  episode?: ?Episode,
|};

export type HeroAndFriendsNamesQuery = {|
  hero: ?( {
      name: string,
      friends: ?Array< ( {
          name: string,
        } | {
          name: string,
        }
      ) >,
    } | {
      name: string,
      friends: ?Array< ( {
          name: string,
        } | {
          name: string,
        }
      ) >,
    }
  ),
|};

// after
export type Episode = "NEWHOPE" | "EMPIRE" | "JEDI";

export type HeroAndFriendsNamesQueryVariables = {|
  +episode?: ?Episode,
|};

export type HeroAndFriendsNamesQuery = {|
  +hero: ?( {
      +name: string,
      +friends: ?$ReadOnlyArray< ( {
          +name: string,
        } | {
          +name: string,
        }
      ) >,
    } | {
      +name: string,
      +friends: ?$ReadOnlyArray< ( {
          +name: string,
        } | {
          +name: string,
        }
      ) >,
    }
  ),
|};
```