### PR TITLE
Add missing dependency to package.json. This dependency was added to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob": "^7.0.5",
     "graphql": "^0.10.0",
     "inflected": "^2.0.2",
+    "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.5.3",
     "sjcl": "^1.0.6",


### PR DESCRIPTION
…`compilation.js` in commit 703edf2 (in version 14.0) that introduced operationIdentifiers to Swift.

Unfortunately this missing dependency doesn't fail in development (using `npm watch` & `npm link`), but fails when `apollo-codegen` is installed with `npm install`.

## Testing

I ensured that this worked by running `npm install -g <local/path/to/apollo-codegen>` followed by `apollo-codegen generate <args>`. I compared the result of running these commands in this branch (a successful code generation) with the result of `master` (an error).

## Version bump

Unfortunately, this will require a minor version bump, since it *actually* introduces the functionality that was thought to be introduced in 14.0 😞 