### PR TITLE
add smoke test to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ install:
 
 script:
   - npm test
+  - npm run test:smoke

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "compile": "tsc",
     "watch": "tsc -w",
     "prepublish": "npm run clean && npm run compile",
-    "test": "jest"
+    "test": "jest",
+    "test:smoke": "rm -rf node_modules && npm install --prod && node ./lib/cli.js && echo 'Smoke Test Passed'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I had the same lodash problem that was fixed in https://github.com/apollographql/apollo-codegen/pull/165 by @kompfner. It looks like the cli would have tested fine as the lodash dependency was still being pulled in by jest.

This PR adds a simple smoke test to make sure that the cli still starts up even when jest isnt around.