### PR TITLE
Update Swift `operationIdentifier` to be a `String?` rather than the …

### DIFF
--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -387,7 +387,7 @@ function operationIdentifier(generator,  { operationName, sourceWithFragments, o
   }
 
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(`public static let operationIdentifier = "${operationId}"`);
+  generator.printOnNewline(`public static let operationIdentifier: String? = "${operationId}"`);
 }
 
 function propertyDeclarationForField(generator, field) {

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -552,7 +552,7 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
     \\"  }\\" +
     \\"}\\"
 
-  public static let operationIdentifier = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
+  public static let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
   public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 


### PR DESCRIPTION
…inferred `String`. This brings it in alignment with the `variables` property, whose default value is provided by its protocol as `nil`.

See discussion in https://github.com/apollographql/apollo-ios/pull/105 for context.