### PR TITLE
Add test/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src/
+test/


### PR DESCRIPTION
Mentioned in #164.

Published versions of apollo-codegen should not publish with tests -- this leads to confusion sometimes when node_modules is indexed/accessed by some other tool.