### PR TITLE
Pass in HTTP Request Method for introspect-schema

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -52,14 +52,21 @@ yargs
         alias: 'K',
         describe: 'Allows "insecure" SSL connection to the server',
         type: 'boolean'
+      },
+      method: {
+        demand: false,
+        describe: 'The HTTP request method to use for the introspection query request',
+        type: 'string',
+        default: 'POST',
+        choices: ['POST', 'GET', 'post', 'get']
       }
     },
     async argv => {
-      const { schema, output, header, insecure } = argv;
+      const { schema, output, header, insecure, method } = argv;
 
       const urlRegex = /^https?:\/\//i;
       if (urlRegex.test(schema)) {
-        await downloadSchema(schema, output, header, insecure);
+        await downloadSchema(schema, output, header, insecure, method);
       } else {
         await introspectSchema(schema, output);
       }

--- a/src/downloadSchema.js
+++ b/src/downloadSchema.js
@@ -18,14 +18,14 @@ const defaultHeaders = {
   'Content-Type': 'application/json'
 };
 
-export default async function downloadSchema(url, outputPath, additionalHeaders, insecure) {
+export default async function downloadSchema(url, outputPath, additionalHeaders, insecure, method) {
   const headers = Object.assign(defaultHeaders, additionalHeaders);
   const agent = insecure ? new https.Agent({ rejectUnauthorized: false }) : null;
 
   let result;
   try {
     const response = await fetch(url, {
-      method: 'POST',
+      method: method,
       headers: headers,
       body: JSON.stringify({ 'query': introspectionQuery }),
       agent,


### PR DESCRIPTION
The method was previously hard-coded as `POST`, this PR allows the user to specify the request method as either `GET` or `POST`.