### PR TITLE
Fix multi-line enum comments

### DIFF
--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -556,12 +556,13 @@ function enumerationDeclaration(generator, type) {
   const values = type.getValues();
 
   generator.printNewlineIfNeeded();
-  generator.printOnNewline(description && `/// ${description}`);
+  comment(generator, description);
   generator.printOnNewline(`public enum ${name}: String`);
   generator.withinBlock(() => {
-    values.forEach(value =>
-      generator.printOnNewline(`case ${escapeIdentifierIfNeeded(enumCaseName(value.name))} = "${value.value}"${wrap(' /// ', value.description)}`)
-    );
+    values.forEach(value => {
+      comment(generator, value.description);
+      generator.printOnNewline(`case ${escapeIdentifierIfNeeded(enumCaseName(value.name))} = "${value.value}"`);
+    });
   });
   generator.printNewline();
   generator.printOnNewline(`extension ${name}: Apollo.JSONDecodable, Apollo.JSONEncodable {}`);

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -1364,9 +1364,12 @@ public struct ReviewInput: GraphQLMapConvertible {
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
 public enum Episode: String {
-  case newhope = \\"NEWHOPE\\" /// Star Wars Episode IV: A New Hope, released in 1977.
-  case empire = \\"EMPIRE\\" /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
-  case jedi = \\"JEDI\\" /// Star Wars Episode VI: Return of the Jedi, released in 1983.
+  /// Star Wars Episode IV: A New Hope, released in 1977.
+  case newhope = \\"NEWHOPE\\"
+  /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  case empire = \\"EMPIRE\\"
+  /// Star Wars Episode VI: Return of the Jedi, released in 1983.
+  case jedi = \\"JEDI\\"
 }
 
 extension Episode: Apollo.JSONDecodable, Apollo.JSONEncodable {}"


### PR DESCRIPTION
Line breaks in enum descriptions were not being preserved as multi-line comments.

I chose to move the comment above the enum case rather than replacing newlines with spaces to keep it all on one line.