### PR TITLE
Set merge-in-fields-from-fragment-spreads as boolean type

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -152,8 +152,9 @@ yargs
       },
       "merge-in-fields-from-fragment-spreads": {
         demand: false,
-        describe: "Merge fragment fields onto its enclosing type [default: true]",
-        default: true
+        describe: "Merge fragment fields onto its enclosing type",
+        default: true,
+        type: 'boolean'
       }
     },
     argv => {


### PR DESCRIPTION
Looks like I'm a big javascript noob, but looks like I needed to include a boolean type flag to make "merge-in-fields-from-fragment-spreads" read a boolean.

I don't see any tests for the CLI, and I'm not sure how to test this locally. @martijnwalraven any advice so I can make sure I did it right this time?