### PR TITLE
Initial support for Scala.js with working queries and mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is a tool to generate API code or type annotations based on a GraphQL schema and query documents.
 
-It currently generates Swift code, TypeScript annotations and Flow annotations, we hope to add support for other targets in the future.
+It currently generates Swift code, TypeScript annotations, Flow annotations, and Scala code, we hope to add support for other targets in the future.
 
-See [Apollo iOS](https://github.com/apollographql/apollo-ios) for details on the mapping from GraphQL results to Swift types, as well as runtime support for executing queries and mutations.
+See [Apollo iOS](https://github.com/apollographql/apollo-ios) for details on the mapping from GraphQL results to Swift types, as well as runtime support for executing queries and mutations. For Scala, see [React Apollo Scala.js](https://github.com/apollographql/react-apollo-scalajs) for details on how to use generated Scala code in a Scala.js app with Apollo Client.
 
 ## Usage
 
@@ -44,13 +44,15 @@ This tool will generate Swift code by default from a set of query definitions in
 apollo-codegen generate **/*.graphql --schema schema.json --output API.swift
 ```
 
-You can also generate type annotations for TypeScript or Flow using the `--target` option:
+You can also generate type annotations for TypeScript, Flow, or Scala using the `--target` option:
 
 ```sh
 # TypeScript
 apollo-codegen generate **/*.graphql --schema schema.json --target typescript --output schema.ts
 # Flow
 apollo-codegen generate **/*.graphql --schema schema.json --target flow --output schema.flow.js
+# Scala
+apollo-codegen generate **/*.graphql --schema schema.json --target scala --output schema.scala
 ```
 
 #### `gql` template support
@@ -63,7 +65,7 @@ The tag name is configurable using the CLI `--tag-name` option.
 
 When using `apollo-codegen` with Typescript or Flow, make sure to add the `__typename` introspection field to every selection set within your graphql operations.
 
-If you're using a client like `apollo-client` that does this automatically for your GraphQL operations, pass in the -`-addTypename` option to `apollo-codegen` to make sure the generated Typescript and Flow types have the `__typename` field as well. This is required to ensure proper type generation support for `GraphQLUnionType` and `GraphQLInterfaceType` fields. 
+If you're using a client like `apollo-client` that does this automatically for your GraphQL operations, pass in the -`-addTypename` option to `apollo-codegen` to make sure the generated Typescript and Flow types have the `__typename` field as well. This is required to ensure proper type generation support for `GraphQLUnionType` and `GraphQLInterfaceType` fields.
 
 ### Why is the __typename field required?
 
@@ -98,11 +100,11 @@ Given this query:
 query Characters {
   characters(episode: NEW_HOPE) {
     name
-    
+
     ... on Human {
       homePlanet
     }
-    
+
     ... on Droid {
       primaryFunction
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -115,12 +115,12 @@ yargs
       target: {
         demand: false,
         describe: 'Code generation target language',
-        choices: ['swift', 'json', 'ts', 'typescript', 'flow'],
+        choices: ['swift', 'scala', 'json', 'ts', 'typescript', 'flow'],
         default: 'swift'
       },
       namespace: {
         demand: false,
-        describe: 'Optional namespace for generated types [currently Swift-only]',
+        describe: 'Optional namespace for generated types [currently Swift and Scala-only]',
         type: 'string'
       },
       "passthrough-custom-scalars": {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -8,8 +8,9 @@ import serializeToJSON from './serializeToJSON'
 import { generateSource as generateSwiftSource } from './swift'
 import { generateSource as generateTypescriptSource } from './typescript'
 import { generateSource as generateFlowSource } from './flow'
+import { generateSource as generateScalaSource } from './scala'
 
-type TargetType = 'json' | 'swift' | 'ts' | 'typescript' | 'flow';
+type TargetType = 'json' | 'swift' | 'ts' | 'typescript' | 'flow' | 'scala';
 
 export default function generate(
   inputPaths: string[],
@@ -47,6 +48,8 @@ export default function generate(
     case 'swift':
       output = generateSwiftSource(context, options);
       break;
+    case 'scala':
+      output = generateScalaSource(context, options);
   }
 
   if (outputPath) {

--- a/src/scala/codeGeneration.js
+++ b/src/scala/codeGeneration.js
@@ -101,11 +101,11 @@ export function classDeclarationForOperation(
   switch (operationType) {
     case 'query':
       objectName = `${operationClassName(operationName)}Query`;
-      protocol = 'me.shadaj.apollo.GraphQLQuery';
+      protocol = 'com.apollographql.scalajs.GraphQLQuery';
       break;
     case 'mutation':
       objectName = `${operationClassName(operationName)}Mutation`;
-      protocol = 'me.shadaj.apollo.GraphQLMutation';
+      protocol = 'com.apollographql.scalajs.GraphQLMutation';
       break;
     default:
       throw new GraphQLError(`Unsupported operation type "${operationType}"`);
@@ -133,9 +133,9 @@ export function classDeclarationForOperation(
       });
       generator.print(' }');
 
-      generator.printOnNewline('val operation = me.shadaj.apollo.gql(requestString)');
+      generator.printOnNewline('val operation = com.apollographql.scalajs.gql(requestString)');
     } else {
-      generator.printOnNewline('val operation = me.shadaj.apollo.gql(operationString)');
+      generator.printOnNewline('val operation = com.apollographql.scalajs.gql(operationString)');
     }
 
     generator.printNewlineIfNeeded();
@@ -154,6 +154,8 @@ export function classDeclarationForOperation(
           type: p.typeName
         };
       })}, () => {});
+    } else {
+      generator.printOnNewline('type Variables = Unit');
     }
 
     caseClassDeclarationForSelectionSet(

--- a/src/scala/codeGeneration.js
+++ b/src/scala/codeGeneration.js
@@ -1,0 +1,373 @@
+import {
+  GraphQLError,
+  getNamedType,
+  isCompositeType,
+  isAbstractType,
+  isEqualType,
+  GraphQLScalarType,
+  GraphQLEnumType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLInputObjectType
+} from 'graphql'
+
+import  { isTypeProperSuperTypeOf } from '../utilities/graphql'
+
+import {
+  join,
+  wrap,
+} from '../utilities/printing';
+
+import {
+  packageDeclaration,
+  objectDeclaration,
+  caseClassDeclaration,
+  propertyDeclaration,
+  propertyDeclarations,
+  escapeIdentifierIfNeeded,
+  comment
+} from './language';
+
+import {
+  caseClassNameForPropertyName,
+  caseClassNameForFragmentName,
+  caseClassNameForInlineFragment,
+  operationClassName,
+  enumCaseName,
+  propertiesFromSelectionSet,
+  propertyFromField,
+  propertyFromInlineFragment,
+  propertyFromFragmentSpread
+} from './naming';
+
+import {
+  escapedString,
+  multilineString,
+  dictionaryLiteralForFieldArguments,
+} from './values';
+
+import {
+  possibleTypesForType,
+  typeNameFromGraphQLType,
+} from './types';
+
+import CodeGenerator from '../utilities/CodeGenerator';
+
+export function generateSource(context, options) {
+  const generator = new CodeGenerator(context);
+
+  generator.printOnNewline('//  This file was automatically generated and should not be edited.');
+  generator.printNewline();
+
+  if (context.namespace) {
+    packageDeclaration(generator, context.namespace);
+  }
+
+  context.typesUsed.forEach(type => {
+    typeDeclarationForGraphQLType(generator, type);
+  });
+
+  Object.values(context.operations).forEach(operation => {
+    classDeclarationForOperation(generator, operation);
+  });
+
+  Object.values(context.fragments).forEach(fragment => {
+    caseClassDeclarationForFragment(generator, fragment);
+  });
+
+  return generator.output;
+}
+
+export function classDeclarationForOperation(
+  generator,
+  {
+    operationName,
+    operationType,
+    rootType,
+    variables,
+    fields,
+    inlineFragments,
+    fragmentSpreads,
+    fragmentsReferenced,
+    source,
+    sourceWithFragments,
+    operationId
+  }
+) {
+  let objectName;
+  let protocol;
+
+  switch (operationType) {
+    case 'query':
+      objectName = `${operationClassName(operationName)}Query`;
+      protocol = 'me.shadaj.apollo.GraphQLQuery';
+      break;
+    case 'mutation':
+      objectName = `${operationClassName(operationName)}Mutation`;
+      protocol = 'me.shadaj.apollo.GraphQLMutation';
+      break;
+    default:
+      throw new GraphQLError(`Unsupported operation type "${operationType}"`);
+  }
+
+  objectDeclaration(generator, {
+    objectName,
+    modifiers: [],
+    superclass: protocol
+  }, () => {
+    if (source) {
+      generator.printOnNewline('val operationString =');
+      generator.withIndent(() => {
+        multilineString(generator, source);
+      });
+    }
+
+    operationIdentifier(generator, { operationName, sourceWithFragments, operationId });
+
+    if (fragmentsReferenced && fragmentsReferenced.length > 0) {
+      generator.printNewlineIfNeeded();
+      generator.printOnNewline('val requestString: String = { operationString');
+      fragmentsReferenced.forEach(fragment => {
+        generator.print(` + ${caseClassNameForFragmentName(fragment)}.fragmentString`)
+      });
+      generator.print(' }');
+
+      generator.printOnNewline('val operation = me.shadaj.apollo.gql(requestString)');
+    } else {
+      generator.printOnNewline('val operation = me.shadaj.apollo.gql(operationString)');
+    }
+
+    generator.printNewlineIfNeeded();
+
+    if (variables && variables.length > 0) {
+      const properties = variables.map(({ name, type }) => {
+        const propertyName = escapeIdentifierIfNeeded(name);
+        const typeName = typeNameFromGraphQLType(generator.context, type);
+        const isOptional = !(type instanceof GraphQLNonNull || type.ofType instanceof GraphQLNonNull);
+        return { name, propertyName, type, typeName, isOptional };
+      });
+
+      caseClassDeclaration(generator, { caseClassName: 'Variables', description: '', params: properties.map(p => {
+        return {
+          name: p.propertyName,
+          type: p.typeName
+        };
+      })}, () => {});
+    }
+
+    caseClassDeclarationForSelectionSet(
+      generator,
+      {
+        caseClassName: "Data",
+        parentType: rootType,
+        fields,
+        inlineFragments,
+        fragmentSpreads
+      }
+    );
+  });
+}
+
+export function caseClassDeclarationForFragment(
+  generator,
+  {
+    fragmentName,
+    typeCondition,
+    fields,
+    inlineFragments,
+    fragmentSpreads,
+    source
+  }
+) {
+  const caseClassName = caseClassNameForFragmentName(fragmentName);
+
+  caseClassDeclarationForSelectionSet(generator, {
+    caseClassName,
+    parentType: typeCondition,
+    fields,
+    inlineFragments,
+    fragmentSpreads
+  }, () => {}, () => {
+    if (source) {
+      generator.printOnNewline('val fragmentString =');
+      generator.withIndent(() => {
+        multilineString(generator, source);
+      });
+    }
+  });
+}
+
+export function caseClassDeclarationForSelectionSet(
+  generator,
+  {
+    caseClassName,
+    parentType,
+    fields,
+    inlineFragments,
+    fragmentSpreads,
+    viewableAs
+  },
+  beforeClosure,
+  objectClosure,
+) {
+  const possibleTypes = parentType ? possibleTypesForType(generator.context, parentType) : null;
+
+  let properties;
+
+  if (!possibleTypes || possibleTypes.length == 1) {
+    properties = fields
+      .map(field => propertyFromField(generator.context, field))
+      .filter(field => field.propertyName != "__typename");
+
+    caseClassDeclaration(generator, { caseClassName, params: properties.map(p => {
+      return {
+        name: p.responseName,
+        type: p.typeName,
+      };
+    }) }, () => {});
+  } else {
+    generator.printNewlineIfNeeded();
+    const properties = fields
+      .map(field => propertyFromField(generator.context, field))
+      .filter(field => field.propertyName != "__typename");
+
+    caseClassDeclaration(generator, { caseClassName, params: properties.map(p => {
+      return {
+        name: p.responseName,
+        type: p.typeName,
+      };
+    }), superclass: 'me.shadaj.slinky.core.WithRaw'}, () => {
+      if (inlineFragments && inlineFragments.length > 0) {
+        inlineFragments.forEach((inlineFragment) => {
+          const fragClass = caseClassNameForInlineFragment(inlineFragment);
+          generator.printOnNewline(`def as${inlineFragment.typeCondition}`);
+          generator.print(`: Option[${fragClass}] =`);
+          generator.withinBlock(() => {
+            generator.printOnNewline(`if (${fragClass}.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[${fragClass}]].read(this.raw)) else None`);
+          });
+        });
+      }
+
+      if (fragmentSpreads) {
+        fragmentSpreads.forEach(s => {
+          const fragment = generator.context.fragments[s];
+          const alwaysDefined = isTypeProperSuperTypeOf(generator.context.schema, fragment.typeCondition, parentType);
+          if (!alwaysDefined) {
+            generator.printOnNewline(`def as${s}`);
+            generator.print(`: Option[${s}] =`);
+            generator.withinBlock(() => {
+              generator.printOnNewline(`if (${s}.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[${s}]].read(this.raw)) else None`);
+            });
+          }
+        })
+      }
+    });
+
+    // add types and implicit conversions
+    if (inlineFragments && inlineFragments.length > 0) {
+      inlineFragments.forEach((inlineFragment) => {
+        caseClassDeclarationForSelectionSet(
+          generator,
+          {
+            caseClassName: caseClassNameForInlineFragment(inlineFragment),
+            parentType: inlineFragment.typeCondition,
+            fields: inlineFragment.fields,
+            inlineFragments: inlineFragment.inlineFragments,
+            fragmentSpreads: inlineFragment.fragmentSpreads,
+            viewableAs: {
+              caseClassName,
+              properties,
+            },
+          }
+        );
+      });
+    }
+  }
+
+  objectDeclaration(generator, { objectName: caseClassName }, () => {
+    if (possibleTypes) {
+      generator.printNewlineIfNeeded();
+      generator.printOnNewline('val possibleTypes = scala.collection.Set(');
+      generator.print(join(possibleTypes.map(type => `"${String(type)}"`), ', '));
+      generator.print(')');
+    }
+
+    if (viewableAs) {
+      generator.printOnNewline(`implicit def to${viewableAs.caseClassName}(a: ${caseClassName}): ${viewableAs.caseClassName} = ${viewableAs.caseClassName}(${viewableAs.properties.map(p => "a." + p.responseName).join(', ')})`);
+    }
+
+    if (fragmentSpreads) {
+      fragmentSpreads.forEach(s => {
+        const fragment = generator.context.fragments[s];
+        const alwaysDefined = isTypeProperSuperTypeOf(generator.context.schema, fragment.typeCondition, parentType);
+        if (alwaysDefined) {
+          generator.printOnNewline(`implicit def to${s}(a: ${caseClassName}): ${s} = ${s}(${(fragment.fields || []).map(p => "a." + p.responseName).join(', ')})`);
+        }
+      })
+    }
+
+    if (objectClosure) {
+      objectClosure();
+    }
+  });
+
+  fields.filter(field => isCompositeType(getNamedType(field.type))).forEach(field => {
+    caseClassDeclarationForSelectionSet(
+      generator,
+      {
+        caseClassName: caseClassNameForPropertyName(field.responseName),
+        parentType: getNamedType(field.type),
+        fields: field.fields,
+        inlineFragments: field.inlineFragments,
+        fragmentSpreads: field.fragmentSpreads
+      }
+    );
+  });
+}
+
+function operationIdentifier(generator,  { operationName, sourceWithFragments, operationId }) {
+  if (!generator.context.generateOperationIds) {
+    return
+  }
+
+  generator.printNewlineIfNeeded();
+  generator.printOnNewline(`val operationIdentifier: String = "${operationId}"`);
+}
+
+export function typeDeclarationForGraphQLType(generator, type) {
+  if (type instanceof GraphQLEnumType) {
+    enumerationDeclaration(generator, type);
+  } else if (type instanceof GraphQLInputObjectType) {
+    caseClassDeclarationForInputObjectType(generator, type);
+  }
+}
+
+function enumerationDeclaration(generator, type) {
+  const { name, description } = type;
+  const values = type.getValues();
+
+  generator.printNewlineIfNeeded();
+  comment(generator, description);
+  generator.printOnNewline(`object ${name}`);
+  generator.withinBlock(() => {
+    values.forEach(value => {
+      comment(generator, value.description);
+      generator.printOnNewline(`val ${escapeIdentifierIfNeeded(enumCaseName(value.name))} = "${value.value}"`);
+    });
+  });
+  generator.printNewline();
+}
+
+function caseClassDeclarationForInputObjectType(generator, type) {
+  const { name: caseClassName, description } = type;
+  const fields = Object.values(type.getFields());
+  const properties = fields.map(field => propertyFromField(generator.context, field));
+
+  caseClassDeclaration(generator, { caseClassName, description, params: properties.map(p => {
+    return {
+      name: p.propertyName,
+      type: p.typeName
+    };
+  })}, () => {});
+}

--- a/src/scala/index.js
+++ b/src/scala/index.js
@@ -1,0 +1,1 @@
+export { generateSource } from './codeGeneration';

--- a/src/scala/language.js
+++ b/src/scala/language.js
@@ -1,0 +1,66 @@
+import {
+  join,
+  wrap,
+} from '../utilities/printing';
+
+export function comment(generator, comment) {
+  const split = comment ? comment.split('\n') : [];
+  if (split.length > 0) {
+    generator.printOnNewline('/**')
+    split.forEach(line => {
+      generator.printOnNewline(` * ${line.trim()}`);
+    });
+
+    generator.printOnNewline(' */');
+  }
+}
+
+export function packageDeclaration(generator, pkg) {
+  generator.printNewlineIfNeeded();
+  generator.printOnNewline(`package ${pkg}`);
+  generator.popScope();
+}
+
+export function objectDeclaration(generator, { objectName, superclass, properties }, closure) {
+  generator.printNewlineIfNeeded();
+  generator.printOnNewline(`object ${objectName}` + (superclass ? ` extends ${superclass}` : ''));
+  generator.pushScope({ typeName: objectName });
+  generator.withinBlock(closure);
+  generator.popScope();
+}
+
+export function caseClassDeclaration(generator, { caseClassName, description, superclass, params }, closure) {
+  generator.printNewlineIfNeeded();
+  comment(generator, description);
+  generator.printOnNewline(`case class ${caseClassName}(${(params || []).map(v => v.name + ": " + v.type).join(', ')})` + (superclass ? ` extends ${superclass}` : ''));
+  generator.pushScope({ typeName: caseClassName });
+  generator.withinBlock(closure);
+  generator.popScope();
+}
+
+export function propertyDeclaration(generator, { propertyName, typeName, description}, closure) {
+  comment(generator, description);
+  generator.printOnNewline(`val ${propertyName}: ${typeName} =`);
+  generator.withinBlock(closure);
+}
+
+export function propertyDeclarations(generator, declarations) {
+  declarations.forEach(o => {
+    propertyDeclaration(generator, o);
+  });
+}
+
+const reservedKeywords = new Set(
+  'case', 'catch', 'class', 'def', 'do', 'else',
+  'extends', 'false', 'final', 'for', 'if', 'match',
+  'new', 'null', 'throw', 'trait', 'true', 'try', 'until',
+  'val', 'var', 'while', 'with'
+);
+
+export function escapeIdentifierIfNeeded(identifier) {
+  if (reservedKeywords.has(identifier)) {
+    return '`' + identifier + '`';
+  } else {
+    return identifier;
+  }
+}

--- a/src/scala/naming.js
+++ b/src/scala/naming.js
@@ -1,0 +1,87 @@
+import { camelCase, pascalCase } from 'change-case';
+import * as Inflector from 'inflected';
+
+import {
+  join
+} from '../utilities/printing';
+
+import {
+  escapeIdentifierIfNeeded
+} from './language';
+
+import {
+  typeNameFromGraphQLType
+} from './types';
+
+import {
+  GraphQLError,
+  GraphQLList,
+  GraphQLNonNull,
+  getNamedType,
+  isCompositeType,
+} from 'graphql';
+
+export function enumCaseName(name) {
+  return camelCase(name);
+}
+
+export function operationClassName(name) {
+  return pascalCase(name);
+}
+
+export function caseClassNameForPropertyName(propertyName) {
+  return pascalCase(Inflector.singularize(propertyName));
+}
+
+export function caseClassNameForFragmentName(fragmentName) {
+  return pascalCase(fragmentName);
+}
+
+export function caseClassNameForInlineFragment(inlineFragment) {
+  return 'As' + pascalCase(String(inlineFragment.typeCondition));
+}
+
+export function propertyFromField(context, field, namespace) {
+  const name = field.name || field.responseName;
+  const unescapedPropertyName = isMetaFieldName(name) ? name : camelCase(name)
+  const propertyName = escapeIdentifierIfNeeded(unescapedPropertyName);
+
+  const type = field.type;
+  const isList = type instanceof GraphQLList || type.ofType instanceof GraphQLList
+  const isOptional = field.isConditional || !(type instanceof GraphQLNonNull);
+  const bareType = getNamedType(type);
+
+  if (isCompositeType(bareType)) {
+    const bareTypeName = join([
+      namespace,
+      escapeIdentifierIfNeeded(pascalCase(Inflector.singularize(name)))
+    ], '.');
+    const typeName = typeNameFromGraphQLType(context, type, bareTypeName, isOptional);
+    return { ...field, propertyName, typeName, bareTypeName, isOptional, isList, isComposite: true };
+  } else {
+    const typeName = typeNameFromGraphQLType(context, type, undefined, isOptional);
+    return { ...field, propertyName, typeName, isOptional, isList, isComposite: false };
+  }
+}
+
+export function propertyFromInlineFragment(context, inlineFragment) {
+  const structName = caseClassNameForInlineFragment(inlineFragment);
+  const propertyName = camelCase(structName);
+  const typeName = structName + '?'
+  return { propertyName, typeName, structName, isComposite: true, ...inlineFragment };
+}
+
+export function propertyFromFragmentSpread(context, fragmentSpread) {
+  const fragmentName = fragmentSpread;
+  const fragment = context.fragments[fragmentName];
+  if (!fragment) {
+    throw new GraphQLError(`Cannot find fragment "${fragmentName}"`);
+  }
+  const propertyName = camelCase(fragmentName);
+  const typeName = caseClassNameForFragmentName(fragmentName);
+  return { propertyName, typeName, fragment, isComposite: true };
+}
+
+function isMetaFieldName(name) {
+  return name.startsWith("__");
+}

--- a/src/scala/types.js
+++ b/src/scala/types.js
@@ -1,0 +1,63 @@
+import {
+  join,
+  block,
+  wrap,
+  indent
+} from '../utilities/printing';
+
+import { camelCase } from 'change-case';
+
+import {
+  GraphQLString,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLScalarType,
+  GraphQLEnumType,
+  isCompositeType,
+  isAbstractType
+} from 'graphql';
+
+const builtInScalarMap = {
+  [GraphQLString.name]: 'String',
+  [GraphQLInt.name]: 'Int',
+  [GraphQLFloat.name]: 'Double',
+  [GraphQLBoolean.name]: 'Boolean',
+  [GraphQLID.name]: 'String',
+}
+
+export function possibleTypesForType(context, type) {
+  if (isAbstractType(type)) {
+    return context.schema.getPossibleTypes(type);
+  } else {
+    return [type];
+  }
+}
+
+export function typeNameFromGraphQLType(context, type, bareTypeName, isOptional) {
+  if (type instanceof GraphQLNonNull) {
+    return typeNameFromGraphQLType(context, type.ofType, bareTypeName, isOptional || false)
+  } else if (isOptional === undefined) {
+    isOptional = true;
+  }
+
+  let typeName;
+  if (type instanceof GraphQLList) {
+    typeName = 'Seq[' + typeNameFromGraphQLType(context, type.ofType, bareTypeName) + ']';
+  } else if (type instanceof GraphQLScalarType) {
+    typeName = typeNameForScalarType(context, type);
+  } else if (type instanceof GraphQLEnumType) {
+    typeName = "String";
+  } else {
+    typeName = bareTypeName || type.name;
+  }
+
+  return isOptional ? `Option[${typeName}]` : typeName;
+}
+
+function typeNameForScalarType(context, type) {
+  return builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: GraphQLString)
+}

--- a/src/scala/values.js
+++ b/src/scala/values.js
@@ -1,0 +1,36 @@
+import {
+  join,
+  wrap,
+} from '../utilities/printing';
+
+export function escapedString(string) {
+  return string.replace(/"/g, '\\"');
+}
+
+export function multilineString(context, string) {
+  const lines = string.split('\n');
+  lines.forEach((line, index) => {
+    const isLastLine = index != lines.length - 1;
+    context.printOnNewline(`"${escapedString(line)}"` + (isLastLine ? ' +' : ''));
+  });
+}
+
+export function dictionaryLiteralForFieldArguments(args) {
+  function expressionFromValue(value) {
+    if (value.kind === 'Variable') {
+      return `Variable("${value.variableName}")`;
+    } else if (Array.isArray(value)) {
+      return wrap('[', join(value.map(expressionFromValue), ', '), ']');
+    } else if (typeof value === 'object') {
+      return wrap('[', join(Object.entries(value).map(([key, value]) => {
+        return `"${key}": ${expressionFromValue(value)}`;
+      }), ', ') || ':', ']');
+    } else {
+      return JSON.stringify(value);
+    }
+  }
+
+  return wrap('[', join(args.map(arg => {
+    return `"${arg.name}": ${expressionFromValue(arg.value)}`;
+  }), ', ') || ':', ']');
+}

--- a/test/scala/__snapshots__/codeGeneration.js.snap
+++ b/test/scala/__snapshots__/codeGeneration.js.snap
@@ -166,7 +166,7 @@ object Friend {
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
-"object CreateReviewMutation extends me.shadaj.apollo.GraphQLMutation {
+"object CreateReviewMutation extends com.apollographql.scalajs.GraphQLMutation {
   val operationString =
     \\"mutation CreateReview($episode: Episode) {\\" +
     \\"  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\" +
@@ -174,7 +174,7 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     \\"    commentary\\" +
     \\"  }\\" +
     \\"}\\"
-  val operation = me.shadaj.apollo.gql(operationString)
+  val operation = com.apollographql.scalajs.gql(operationString)
 
 
   case class Variables(episode: Option[String]) {
@@ -197,7 +197,7 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
-"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+"object HeroQuery extends com.apollographql.scalajs.GraphQLQuery {
   val operationString =
     \\"query Hero {\\" +
     \\"  hero {\\" +
@@ -208,8 +208,9 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     \\"}\\"
 
   val requestString: String = { operationString + HeroDetails.fragmentString }
-  val operation = me.shadaj.apollo.gql(requestString)
+  val operation = com.apollographql.scalajs.gql(requestString)
 
+  type Variables = Unit
 
   case class Data(hero: Option[Hero]) {
   }
@@ -241,7 +242,7 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
-"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+"object HeroQuery extends com.apollographql.scalajs.GraphQLQuery {
   val operationString =
     \\"query Hero {\\" +
     \\"  hero {\\" +
@@ -250,8 +251,9 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     \\"}\\"
 
   val requestString: String = { operationString + DroidDetails.fragmentString }
-  val operation = me.shadaj.apollo.gql(requestString)
+  val operation = com.apollographql.scalajs.gql(requestString)
 
+  type Variables = Unit
 
   case class Data(hero: Option[Hero]) {
   }
@@ -286,7 +288,7 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
-"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+"object HeroQuery extends com.apollographql.scalajs.GraphQLQuery {
   val operationString =
     \\"query Hero {\\" +
     \\"  hero {\\" +
@@ -295,8 +297,9 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     \\"}\\"
 
   val requestString: String = { operationString + HeroDetails.fragmentString }
-  val operation = me.shadaj.apollo.gql(requestString)
+  val operation = com.apollographql.scalajs.gql(requestString)
 
+  type Variables = Unit
 
   case class Data(hero: Option[Hero]) {
   }
@@ -317,14 +320,14 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
-"object HeroNameQuery extends me.shadaj.apollo.GraphQLQuery {
+"object HeroNameQuery extends com.apollographql.scalajs.GraphQLQuery {
   val operationString =
     \\"query HeroName($episode: Episode) {\\" +
     \\"  hero(episode: $episode) {\\" +
     \\"    name\\" +
     \\"  }\\" +
     \\"}\\"
-  val operation = me.shadaj.apollo.gql(operationString)
+  val operation = com.apollographql.scalajs.gql(operationString)
 
 
   case class Variables(episode: Option[String]) {
@@ -348,7 +351,7 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 `;
 
 exports[`Scala code generation #classDeclarationForOperation() when generateOperationIds is specified should generate a class declaration with an operationId property 1`] = `
-"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+"object HeroQuery extends com.apollographql.scalajs.GraphQLQuery {
   val operationString =
     \\"query Hero {\\" +
     \\"  hero {\\" +
@@ -359,8 +362,9 @@ exports[`Scala code generation #classDeclarationForOperation() when generateOper
   val operationIdentifier: String = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
   val requestString: String = { operationString + HeroDetails.fragmentString }
-  val operation = me.shadaj.apollo.gql(requestString)
+  val operation = com.apollographql.scalajs.gql(requestString)
 
+  type Variables = Unit
 
   case class Data(hero: Option[Hero]) {
   }

--- a/test/scala/__snapshots__/codeGeneration.js.snap
+++ b/test/scala/__snapshots__/codeGeneration.js.snap
@@ -1,0 +1,433 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scala code generation #caseClassDeclarationForFragment() should generate a caseClass declaration for a fragment that includes a fragment spread 1`] = `
+"case class HeroDetails(name: String, appearsIn: Seq[Option[String]]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object HeroDetails {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  implicit def toMoreHeroDetails(a: HeroDetails): MoreHeroDetails = MoreHeroDetails(a.appearsIn)
+  val fragmentString =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  name\\" +
+    \\"  ...MoreHeroDetails\\" +
+    \\"}\\"
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForFragment() should generate a caseClass declaration for a fragment with a concrete type condition 1`] = `
+"case class DroidDetails(name: String, primaryFunction: Option[String]) {
+}
+
+object DroidDetails {
+  val possibleTypes = scala.collection.Set(\\"Droid\\")
+  val fragmentString =
+    \\"fragment DroidDetails on Droid {\\" +
+    \\"  name\\" +
+    \\"  primaryFunction\\" +
+    \\"}\\"
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForFragment() should generate a caseClass declaration for a fragment with a subselection 1`] = `
+"case class HeroDetails(name: String, friends: Option[Seq[Option[Friend]]]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object HeroDetails {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  val fragmentString =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  name\\" +
+    \\"  friends {\\" +
+    \\"    name\\" +
+    \\"  }\\" +
+    \\"}\\"
+}
+
+
+case class Friend(name: String) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Friend {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForFragment() should generate a caseClass declaration for a fragment with an abstract type condition 1`] = `
+"case class HeroDetails(name: String, appearsIn: Seq[Option[String]]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object HeroDetails {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  val fragmentString =
+    \\"fragment HeroDetails on Character {\\" +
+    \\"  name\\" +
+    \\"  appearsIn\\" +
+    \\"}\\"
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should escape reserved keywords in a caseClass declaration for a selection set 1`] = `
+"case class Hero(private: Option[String]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a caseClass declaration for a fragment spread nested in an inline fragment 1`] = `
+"case class Hero() extends me.shadaj.slinky.core.WithRaw {
+  def asDroid: Option[AsDroid] = {
+    if (AsDroid.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[AsDroid]].read(this.raw)) else None
+  }
+}
+
+case class AsDroid() {
+}
+
+object AsDroid {
+  val possibleTypes = scala.collection.Set(\\"Droid\\")
+  implicit def toHero(a: AsDroid): Hero = Hero()
+  implicit def toHeroDetails(a: AsDroid): HeroDetails = HeroDetails()
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a caseClass declaration for a selection set 1`] = `
+"case class Hero(name: Option[String]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a caseClass declaration for a selection set with a fragment spread that matches the parent type 1`] = `
+"case class Hero(name: Option[String]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  implicit def toHeroDetails(a: Hero): HeroDetails = HeroDetails()
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a caseClass declaration for a selection set with a fragment spread with a more specific type condition 1`] = `
+"case class Hero(name: Option[String]) extends me.shadaj.slinky.core.WithRaw {
+  def asDroidDetails: Option[DroidDetails] = {
+    if (DroidDetails.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[DroidDetails]].read(this.raw)) else None
+  }
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a caseClass declaration for a selection set with an inline fragment 1`] = `
+"case class Hero(name: String) extends me.shadaj.slinky.core.WithRaw {
+  def asDroid: Option[AsDroid] = {
+    if (AsDroid.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[AsDroid]].read(this.raw)) else None
+  }
+}
+
+case class AsDroid(name: String, primaryFunction: Option[String]) {
+}
+
+object AsDroid {
+  val possibleTypes = scala.collection.Set(\\"Droid\\")
+  implicit def toHero(a: AsDroid): Hero = Hero(a.name)
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #caseClassDeclarationForSelectionSet() should generate a nested caseClass declaration for a selection set with subselections 1`] = `
+"case class Hero(friends: Option[Seq[Option[Friend]]]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Hero {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}
+
+
+case class Friend(name: Option[String]) extends me.shadaj.slinky.core.WithRaw {
+}
+
+object Friend {
+  val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
+"object CreateReviewMutation extends me.shadaj.apollo.GraphQLMutation {
+  val operationString =
+    \\"mutation CreateReview($episode: Episode) {\\" +
+    \\"  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\" +
+    \\"    stars\\" +
+    \\"    commentary\\" +
+    \\"  }\\" +
+    \\"}\\"
+  val operation = me.shadaj.apollo.gql(operationString)
+
+
+  case class Variables(episode: Option[String]) {
+  }
+
+  case class Data(createReview: Option[CreateReview]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Mutation\\")
+  }
+
+  case class CreateReview(stars: Int, commentary: Option[String]) {
+  }
+
+  object CreateReview {
+    val possibleTypes = scala.collection.Set(\\"Review\\")
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
+"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+  val operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    ... on Droid {\\" +
+    \\"      ...HeroDetails\\" +
+    \\"    }\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  val requestString: String = { operationString + HeroDetails.fragmentString }
+  val operation = me.shadaj.apollo.gql(requestString)
+
+
+  case class Data(hero: Option[Hero]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+  }
+
+
+  case class Hero() extends me.shadaj.slinky.core.WithRaw {
+    def asDroid: Option[AsDroid] = {
+      if (AsDroid.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[AsDroid]].read(this.raw)) else None
+    }
+  }
+
+  case class AsDroid(name: String) {
+  }
+
+  object AsDroid {
+    val possibleTypes = scala.collection.Set(\\"Droid\\")
+    implicit def toHero(a: AsDroid): Hero = Hero()
+    implicit def toHeroDetails(a: AsDroid): HeroDetails = HeroDetails(a.name)
+  }
+
+  object Hero {
+    val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
+"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+  val operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    ...DroidDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  val requestString: String = { operationString + DroidDetails.fragmentString }
+  val operation = me.shadaj.apollo.gql(requestString)
+
+
+  case class Data(hero: Option[Hero]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+  }
+
+
+  case class Hero() extends me.shadaj.slinky.core.WithRaw {
+    def asDroid: Option[AsDroid] = {
+      if (AsDroid.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[AsDroid]].read(this.raw)) else None
+    }
+    def asDroidDetails: Option[DroidDetails] = {
+      if (DroidDetails.possibleTypes.contains(this.raw.__typename.asInstanceOf[String])) Some(implicitly[me.shadaj.slinky.core.Reader[DroidDetails]].read(this.raw)) else None
+    }
+  }
+
+  case class AsDroid(primaryFunction: Option[String]) {
+  }
+
+  object AsDroid {
+    val possibleTypes = scala.collection.Set(\\"Droid\\")
+    implicit def toHero(a: AsDroid): Hero = Hero()
+    implicit def toDroidDetails(a: AsDroid): DroidDetails = DroidDetails(a.primaryFunction)
+  }
+
+  object Hero {
+    val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
+"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+  val operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    ...HeroDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  val requestString: String = { operationString + HeroDetails.fragmentString }
+  val operation = me.shadaj.apollo.gql(requestString)
+
+
+  case class Data(hero: Option[Hero]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+  }
+
+
+  case class Hero(name: String) extends me.shadaj.slinky.core.WithRaw {
+  }
+
+  object Hero {
+    val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+    implicit def toHeroDetails(a: Hero): HeroDetails = HeroDetails(a.name)
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
+"object HeroNameQuery extends me.shadaj.apollo.GraphQLQuery {
+  val operationString =
+    \\"query HeroName($episode: Episode) {\\" +
+    \\"  hero(episode: $episode) {\\" +
+    \\"    name\\" +
+    \\"  }\\" +
+    \\"}\\"
+  val operation = me.shadaj.apollo.gql(operationString)
+
+
+  case class Variables(episode: Option[String]) {
+  }
+
+  case class Data(hero: Option[Hero]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+  }
+
+
+  case class Hero(name: String) extends me.shadaj.slinky.core.WithRaw {
+  }
+
+  object Hero {
+    val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() when generateOperationIds is specified should generate a class declaration with an operationId property 1`] = `
+"object HeroQuery extends me.shadaj.apollo.GraphQLQuery {
+  val operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    ...HeroDetails\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  val operationIdentifier: String = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
+
+  val requestString: String = { operationString + HeroDetails.fragmentString }
+  val operation = me.shadaj.apollo.gql(requestString)
+
+
+  case class Data(hero: Option[Hero]) {
+  }
+
+  object Data {
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+  }
+
+
+  case class Hero(name: String) extends me.shadaj.slinky.core.WithRaw {
+  }
+
+  object Hero {
+    val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+    implicit def toHeroDetails(a: Hero): HeroDetails = HeroDetails(a.name)
+  }
+}"
+`;
+
+exports[`Scala code generation #classDeclarationForOperation() when generateOperationIds is specified should generate appropriate operation id mapping source when there are nested fragment references 1`] = `
+"query Hero {
+  hero {
+    ...HeroDetails
+  }
+}
+fragment HeroDetails on Character {
+  ...HeroName
+  appearsIn
+}
+fragment HeroName on Character {
+  name
+}"
+`;
+
+exports[`Scala code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
+"object AlbumPrivacies {
+  val public = \\"PUBLIC\\"
+  val private = \\"PRIVATE\\"
+}
+"
+`;
+
+exports[`Scala code generation #typeDeclarationForGraphQLType() should generate a caseClass declaration for a GraphQLInputObjectType 1`] = `
+"/**
+ * The input object sent when someone is creating a new review
+ */
+case class ReviewInput(stars: Int, commentary: Option[String], favoriteColor: Option[ColorInput]) {
+}"
+`;
+
+exports[`Scala code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
+"/**
+ * The episodes in the Star Wars trilogy
+ */
+object Episode {
+  /**
+   * Star Wars Episode IV: A New Hope, released in 1977.
+   */
+  val newhope = \\"NEWHOPE\\"
+  /**
+   * Star Wars Episode V: The Empire Strikes Back, released in 1980.
+   */
+  val empire = \\"EMPIRE\\"
+  /**
+   * Star Wars Episode VI: Return of the Jedi, released in 1983.
+   */
+  val jedi = \\"JEDI\\"
+}
+"
+`;

--- a/test/scala/__snapshots__/language.js.snap
+++ b/test/scala/__snapshots__/language.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scala code generation: Basic language constructs should handle multi-line descriptions 1`] = `
+"/**
+ * A hero
+ */
+case class Hero() {
+  /**
+   * A multiline comment
+   * on the hero's name.
+   */
+  val name: String = {
+  }
+  /**
+   * A multiline comment
+   * on the hero's age.
+   */
+  val age: String = {
+  }
+}"
+`;

--- a/test/scala/codeGeneration.js
+++ b/test/scala/codeGeneration.js
@@ -1,0 +1,554 @@
+import { stripIndent } from 'common-tags';
+
+import {
+  parse,
+  isType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLInputObjectType,
+  GraphQLEnumType
+} from 'graphql';
+
+import {
+  classDeclarationForOperation,
+  caseClassDeclarationForFragment,
+  caseClassDeclarationForSelectionSet,
+  typeDeclarationForGraphQLType,
+} from '../../src/scala/codeGeneration';
+
+import {
+  dictionaryLiteralForFieldArguments,
+} from '../../src/scala/values';
+
+import { loadSchema } from '../../src/loading';
+const schema = loadSchema(require.resolve('../starwars/schema.json'));
+
+import CodeGenerator from '../../src/utilities/CodeGenerator';
+
+import { compileToIR } from '../../src/compilation';
+
+describe('Scala code generation', function() {
+  let generator;
+  let resetGenerator;
+  let compileFromSource;
+  let addFragment;
+
+  beforeEach(function() {
+
+    resetGenerator = () => {
+      const context = {
+        schema: schema,
+        operations: {},
+        fragments: {},
+        typesUsed: {}
+      }
+      generator = new CodeGenerator(context);  
+    };
+
+    compileFromSource = (source, options = { generateOperationIds: false }) => {
+      const document = parse(source);
+      let context = compileToIR(schema, document);
+      options.generateOperationIds && Object.assign(context, { generateOperationIds: true, operationIdsMap: {} });
+      generator.context = context;
+      return context;
+    };
+
+    addFragment = (fragment) => {
+      generator.context.fragments[fragment.fragmentName] = fragment;
+    };
+
+    resetGenerator();
+  });
+
+  describe('#classDeclarationForOperation()', function() {
+    test(`should generate a class declaration for a query with variables`, function() {
+      const { operations, fragments } = compileFromSource(`
+        query HeroName($episode: Episode) {
+          hero(episode: $episode) {
+            name
+          }
+        }
+      `);
+
+      classDeclarationForOperation(generator, operations['HeroName'], Object.values(fragments));
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a class declaration for a query with fragment spreads`, function() {
+      const { operations, fragments } = compileFromSource(`
+        query Hero {
+          hero {
+            ...HeroDetails
+          }
+        }
+
+        fragment HeroDetails on Character {
+          name
+        }
+      `);
+
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a class declaration for a query with conditional fragment spreads`, function() {
+      const { operations, fragments } = compileFromSource(`
+        query Hero {
+          hero {
+            ...DroidDetails
+          }
+        }
+
+        fragment DroidDetails on Droid {
+          primaryFunction
+        }
+      `);
+
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
+      const { operations, fragments } = compileFromSource(`
+        query Hero {
+          hero {
+            ... on Droid {
+              ...HeroDetails
+            }
+          }
+        }
+
+        fragment HeroDetails on Character {
+          name
+        }
+      `);
+
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a class declaration for a mutation with variables`, function() {
+      const { operations, fragments } = compileFromSource(`
+        mutation CreateReview($episode: Episode) {
+          createReview(episode: $episode, review: { stars: 5, commentary: "Wow!" }) {
+            stars
+            commentary
+          }
+        }
+      `);
+
+      classDeclarationForOperation(generator, operations['CreateReview'], Object.values(fragments));
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    describe(`when generateOperationIds is specified`, function() {
+      let compileOptions = { generateOperationIds: true };
+
+      test(`should generate a class declaration with an operationId property`, function() {
+        const context = compileFromSource(`
+          query Hero {
+            hero {
+              ...HeroDetails
+            }
+          }
+          fragment HeroDetails on Character {
+            name
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context.operations['Hero'], Object.values(context.fragments));
+        expect(generator.output).toMatchSnapshot();
+      });
+
+      test(`should generate different operation ids for different operations`, function() {
+        const context1 = compileFromSource(`
+          query Hero {
+            hero {
+              ...HeroDetails
+            }
+          }
+          fragment HeroDetails on Character {
+            name
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context1.operations['Hero'], Object.values(context1.fragments));
+        const output1 = generator.output;
+
+        resetGenerator();
+        const context2 = compileFromSource(`
+          query Hero {
+            hero {
+              ...HeroDetails
+            }
+          }
+          fragment HeroDetails on Character {
+            appearsIn
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context2.operations['Hero'], Object.values(context2.fragments));
+        const output2 = generator.output;
+
+        expect(output1).not.toBe(output2);
+      });
+
+      test(`should generate the same operation id regardless of operation formatting/commenting`, function() {
+        const context1 = compileFromSource(`
+          query HeroName($episode: Episode) {
+            hero(episode: $episode) {
+              name
+            }
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context1.operations['HeroName'], Object.values(context1.fragments));
+        const output1 = generator.output;
+
+        resetGenerator();
+        const context2 = compileFromSource(`
+          # Profound comment
+          query HeroName($episode:Episode) { hero(episode: $episode) { name } }
+          # Deeply meaningful comment
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context2.operations['HeroName'], Object.values(context2.fragments));
+        const output2 = generator.output;
+
+        expect(output1).toBe(output2);
+      });
+
+      test(`should generate the same operation id regardless of fragment order`, function() {
+        const context1 = compileFromSource(`
+          query Hero {
+            hero {
+              ...HeroName
+              ...HeroAppearsIn
+            }
+          }
+          fragment HeroName on Character {
+            name
+          }
+          fragment HeroAppearsIn on Character {
+            appearsIn
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context1.operations['Hero'], Object.values(context1.fragments));
+        const output1 = generator.output;
+
+        resetGenerator();
+        const context2 = compileFromSource(`
+          query Hero {
+            hero {
+              ...HeroName
+              ...HeroAppearsIn
+            }
+          }
+          fragment HeroAppearsIn on Character {
+            appearsIn
+          }
+          fragment HeroName on Character {
+            name
+          }
+        `, compileOptions);
+
+        classDeclarationForOperation(generator, context2.operations['Hero'], Object.values(context2.fragments));
+        const output2 = generator.output;
+
+        expect(output1).toBe(output2);
+      });
+
+      test(`should generate appropriate operation id mapping source when there are nested fragment references`, function() {
+        const source = `
+          query Hero {
+            hero {
+              ...HeroDetails
+            }
+          }
+          fragment HeroName on Character {
+            name
+          }
+          fragment HeroDetails on Character {
+            ...HeroName
+            appearsIn
+          }
+        `;
+        const context = compileFromSource(source, true);
+        expect(context.operations['Hero'].sourceWithFragments).toMatchSnapshot();
+      });
+
+    });
+  });
+
+  describe('#caseClassDeclarationForFragment()', function() {
+    test(`should generate a caseClass declaration for a fragment with an abstract type condition`, function() {
+      const { fragments } = compileFromSource(`
+        fragment HeroDetails on Character {
+          name
+          appearsIn
+        }
+      `);
+
+      caseClassDeclarationForFragment(generator, fragments['HeroDetails']);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a fragment with a concrete type condition`, function() {
+      const { fragments } = compileFromSource(`
+        fragment DroidDetails on Droid {
+          name
+          primaryFunction
+        }
+      `);
+
+      caseClassDeclarationForFragment(generator, fragments['DroidDetails']);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a fragment with a subselection`, function() {
+      const { fragments } = compileFromSource(`
+        fragment HeroDetails on Character {
+          name
+          friends {
+            name
+          }
+        }
+      `);
+
+      caseClassDeclarationForFragment(generator, fragments['HeroDetails']);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a fragment that includes a fragment spread`, function() {
+      const { fragments } = compileFromSource(`
+        fragment HeroDetails on Character {
+          name
+          ...MoreHeroDetails
+        }
+
+        fragment MoreHeroDetails on Character {
+          appearsIn
+        }
+      `);
+
+      caseClassDeclarationForFragment(generator, fragments['HeroDetails']);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+  });
+
+  describe('#caseClassDeclarationForSelectionSet()', function() {
+    test(`should generate a caseClass declaration for a selection set`, function() {
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fields: [
+          {
+            responseName: 'name',
+            fieldName: 'name',
+            type: GraphQLString
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should escape reserved keywords in a caseClass declaration for a selection set`, function() {
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fields: [
+          {
+            responseName: 'private',
+            fieldName: 'name',
+            type: GraphQLString
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a nested caseClass declaration for a selection set with subselections`, function() {
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fields: [
+          {
+            responseName: 'friends',
+            fieldName: 'friends',
+            type: new GraphQLList(schema.getType('Character')),
+            fields: [
+              {
+                responseName: 'name',
+                fieldName: 'name',
+                type: GraphQLString
+              }
+            ]
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a selection set with a fragment spread that matches the parent type`, function() {
+      addFragment({
+        fragmentName: 'HeroDetails',
+        typeCondition: schema.getType('Character')
+      });
+
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fragmentSpreads: ['HeroDetails'],
+        fields: [
+          {
+            responseName: 'name',
+            fieldName: 'name',
+            type: GraphQLString
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a selection set with a fragment spread with a more specific type condition`, function() {
+      addFragment({
+        fragmentName: 'DroidDetails',
+        typeCondition: schema.getType('Droid')
+      });
+
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fragmentSpreads: ['DroidDetails'],
+        fields: [
+          {
+            responseName: 'name',
+            fieldName: 'name',
+            type: GraphQLString
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a selection set with an inline fragment`, function() {
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fields: [
+          {
+            responseName: 'name',
+            fieldName: 'name',
+            type: new GraphQLNonNull(GraphQLString)
+          }
+        ],
+        inlineFragments: [
+          {
+            typeCondition: schema.getType('Droid'),
+            possibleTypes: ['Droid'],
+            fields: [
+              {
+                responseName: 'name',
+                fieldName: 'name',
+                type: new GraphQLNonNull(GraphQLString)
+              },
+              {
+                responseName: 'primaryFunction',
+                fieldName: 'primaryFunction',
+                type: GraphQLString
+              }
+            ]
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test(`should generate a caseClass declaration for a fragment spread nested in an inline fragment`, function() {
+      addFragment({
+        fragmentName: 'HeroDetails',
+        typeCondition: schema.getType('Character')
+      });
+
+      caseClassDeclarationForSelectionSet(generator, {
+        caseClassName: 'Hero',
+        parentType: schema.getType('Character'),
+        fields: [],
+        inlineFragments: [
+          {
+            typeCondition: schema.getType('Droid'),
+            possibleTypes: ['Droid'],
+            fields: [],
+            fragmentSpreads: ['HeroDetails'],
+          }
+        ]
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+  });
+
+  describe('#dictionaryLiteralForFieldArguments()', function() {
+    test('should include expressions for input objects with variables', function() {
+      const { operations } = compileFromSource(`
+        mutation FieldArgumentsWithInputObjects($commentary: String!, $red: Int!) {
+          createReview(episode: JEDI, review: { stars: 2, commentary: $commentary, favorite_color: { red: $red, blue: 100, green: 50 } }) {
+            commentary
+          }
+        }
+      `);
+
+      const fieldArguments = operations['FieldArgumentsWithInputObjects'].fields[0].args;
+      const dictionaryLiteral = dictionaryLiteralForFieldArguments(fieldArguments);
+
+      expect(dictionaryLiteral).toBe('["episode": "JEDI", "review": ["stars": 2, "commentary": Variable("commentary"), "favorite_color": ["red": Variable("red"), "blue": 100, "green": 50]]]');
+    });
+  });
+
+  describe('#typeDeclarationForGraphQLType()', function() {
+    test('should generate an enum declaration for a GraphQLEnumType', function() {
+      const generator = new CodeGenerator();
+
+      typeDeclarationForGraphQLType(generator, schema.getType('Episode'));
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test('should escape identifiers in cases of enum declaration for a GraphQLEnumType', function() {
+      const generator = new CodeGenerator();
+
+      const albumPrivaciesEnum = new GraphQLEnumType({
+        name: 'AlbumPrivacies',
+        values: { PUBLIC: { value: "PUBLIC" }, PRIVATE: { value: "PRIVATE" } }
+      });
+
+      typeDeclarationForGraphQLType(generator, albumPrivaciesEnum);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    test('should generate a caseClass declaration for a GraphQLInputObjectType', function() {
+      const generator = new CodeGenerator();
+
+      typeDeclarationForGraphQLType(generator, schema.getType('ReviewInput'));
+
+      expect(generator.output).toMatchSnapshot();
+    });
+  });
+});

--- a/test/scala/language.js
+++ b/test/scala/language.js
@@ -1,0 +1,64 @@
+import { stripIndent } from 'common-tags';
+
+import CodeGenerator from '../../src/utilities/CodeGenerator';
+
+import {
+  objectDeclaration,
+  caseClassDeclaration,
+  propertyDeclaration,
+} from '../../src/scala/language';
+
+describe('Scala code generation: Basic language constructs', function() {
+  let generator;
+
+  beforeEach(function() {
+    generator = new CodeGenerator();
+  });
+
+  test(`should generate a object declaration`, function() {
+    objectDeclaration(generator, { objectName: 'Hero' }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String' }, () => {});
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'Int' }, () => {});
+    });
+
+    expect(generator.output).toBe(stripIndent`
+      object Hero {
+        val name: String = {
+        }
+        val age: Int = {
+        }
+      }
+    `);
+  });
+
+  test(`should generate a case class declaration`, function() {
+    caseClassDeclaration(generator, { caseClassName: 'Hero', params: [{name: 'name', type: 'String'}, {name: 'age', type: 'Int'}] }, () => {});
+
+    expect(generator.output).toBe(stripIndent`
+      case class Hero(name: String, age: Int) {
+      }
+    `);
+  });
+
+  test(`should generate nested case class declarations`, function() {
+    caseClassDeclaration(generator, { caseClassName: 'Hero', params: [{name: 'name', type: 'String'}, {name: 'age', type: 'Int'}] }, () => {
+      caseClassDeclaration(generator, { caseClassName: 'Friend', params: [{name: 'name', type: 'String'}] }, () => {});
+    });
+
+    expect(generator.output).toBe(stripIndent`
+      case class Hero(name: String, age: Int) {
+        case class Friend(name: String) {
+        }
+      }
+    `);
+  });
+
+  test(`should handle multi-line descriptions`, () => {
+    caseClassDeclaration(generator, { caseClassName: 'Hero', description: 'A hero' }, () => {
+      propertyDeclaration(generator, { propertyName: 'name', typeName: 'String', description: `A multiline comment \n on the hero's name.` }, () => {});
+      propertyDeclaration(generator, { propertyName: 'age', typeName: 'String', description: `A multiline comment \n on the hero's age.` }, () => {});
+    });
+
+    expect(generator.output).toMatchSnapshot();
+  });
+});

--- a/test/scala/types.js
+++ b/test/scala/types.js
@@ -1,0 +1,83 @@
+import { stripIndent } from 'common-tags'
+
+import {
+  GraphQLString,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLScalarType,
+} from 'graphql';
+
+import { loadSchema } from '../../src/loading'
+const schema = loadSchema(require.resolve('../starwars/schema.json'));
+
+import CodeGenerator from '../../src/utilities/CodeGenerator';
+
+import { typeNameFromGraphQLType } from '../../src/scala/types'
+
+describe('Scala code generation: Types', function() {
+  describe('#typeNameFromGraphQLType()', function() {
+    test('should return Option[String] for GraphQLString', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLString)).toBe('Option[String]');
+    });
+
+    test('should return String for GraphQLNonNull(GraphQLString)', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(GraphQLString))).toBe('String');
+    });
+
+    test('should return Option[Seq[Option[String]]] for GraphQLList(GraphQLString)', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(GraphQLString))).toBe('Option[Seq[Option[String]]]');
+    });
+
+    test('should return Seq[String] for GraphQLNonNull(GraphQLList(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(GraphQLString)))).toBe('Seq[Option[String]]');
+    });
+
+    test('should return Option[Seq[String]] for GraphQLList(GraphQLNonNull(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(GraphQLString)))).toBe('Option[Seq[String]]');
+    });
+
+    test('should return Seq[String] for GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString)))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))))).toBe('Seq[String]');
+    });
+
+    test('should return Option[Seq[Option[Seq[Option[String]]]]] for GraphQLList(GraphQLList(GraphQLString))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLList(GraphQLString)))).toBe('Option[Seq[Option[Seq[Option[String]]]]]');
+    });
+
+    test('should return Option[Seq[Seq[Option[String]]]] for GraphQLList(GraphQLNonNull(GraphQLList(GraphQLString)))', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLList(new GraphQLNonNull(new GraphQLList(GraphQLString))))).toBe('Option[Seq[Seq[Option[String]]]]');
+    });
+
+    test('should return Option[Int] for GraphQLInt', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLInt)).toBe('Option[Int]');
+    });
+
+    test('should return Option[Double] for GraphQLFloat', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLFloat)).toBe('Option[Double]');
+    });
+
+    test('should return Option[Boolean] for GraphQLBoolean', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLBoolean)).toBe('Option[Boolean]');
+    });
+
+    test('should return Option[String] for GraphQLID', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLID)).toBe('Option[String]');
+    });
+
+    test('should return Option[String] for a custom scalar type', function() {
+      expect(typeNameFromGraphQLType({}, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('Option[String]');
+    });
+
+    test('should return a passed through custom scalar type with the passthroughCustomScalars option', function() {
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: '' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('Option[CustomScalarType]');
+    });
+
+    test('should return a passed through custom scalar type with a prefix with the customScalarsPrefix option', function() {
+      expect(typeNameFromGraphQLType({ passthroughCustomScalars: true, customScalarsPrefix: 'My' }, new GraphQLScalarType({ name: 'CustomScalarType', serialize: String }))).toBe('Option[MyCustomScalarType]');
+    });
+  });
+});


### PR DESCRIPTION
Adds a new target to `apollo-codegen` that emits Scala types for queries through `case class` model types and companion objects that provide type conversions.