### PR TITLE
`Replace `sjcl` with standard `crypto` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.5.3",
-    "sjcl": "^1.0.6",
     "source-map-support": "^0.4.15",
     "yargs": "^8.0.1"
   },

--- a/src/compilation.js
+++ b/src/compilation.js
@@ -49,7 +49,9 @@ import {
   uniqBy 
 } from 'lodash';
 
-import * as sjcl from 'sjcl';
+import {
+  createHash,
+} from 'crypto';
 
 // Parts of this code are adapted from graphql-js
 
@@ -433,8 +435,9 @@ function augmentCompiledOperationWithFragments(compiledOperation, compiledFragme
   compiledOperation.sourceWithFragments = operationAndFragments.map(operationOrFragment => { 
     return operationOrFragment.source; 
   }).join('\n');
-  const idBits = sjcl.hash.sha256.hash(compiledOperation.sourceWithFragments);
-  compiledOperation.operationId = sjcl.codec.hex.fromBits(idBits);
+  const hash = createHash('sha256')
+  hash.update(compiledOperation.sourceWithFragments)
+  compiledOperation.operationId = hash.digest('hex');
 }
 
 function operationAndRelatedFragments(compiledOperationOrFragment, allCompiledFragments) {


### PR DESCRIPTION
I'm not familiar with `sjcl` but it seemed silly to introduce a
new dependency when node includes sha256 hashing in the standard libs.