### PR TITLE
Allow spaces between tag name and backquote

### DIFF
--- a/src/loading.ts
+++ b/src/loading.ts
@@ -26,7 +26,7 @@ export function loadSchema(schemaPath: string): GraphQLSchema {
 }
 
 function extractDocumentFromJavascript(content: string, tagName: string = 'gql'): string | null {
-  const re = new RegExp(tagName + '`([^`]*)`', 'g');
+  const re = new RegExp(tagName + '\\s*`([^`]*)`', 'g');
 
   let match
   const matches = []


### PR DESCRIPTION
The following tagged template literal `q1` and `q2` are valid syntax in JS and TS, however apollo-codegen extracts GraphQL query from not `q1` but only `q2`.

```ts
const q1 = gql    `query MyQuery { ... }`; // Not extracted
const q2 = gql`query MyQuery { ... }`;   // Extracted 
```