### PR TITLE
close apollographql/apollo-ios#124 Add in deprecations for swift

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -37,6 +37,7 @@ import {
   propertyDeclarations,
   escapeIdentifierIfNeeded,
   comment,
+  deprecation,
   Property
 } from './language';
 
@@ -434,7 +435,7 @@ function operationIdentifier(
 }
 
 function propertyDeclarationForField(generator: CodeGenerator, field: Field) {
-  const { kind, propertyName, typeName, type, isConditional, description } = propertyFromField(
+  const { kind, propertyName, typeName, type, isConditional, description, isDeprecated, deprecationReason } = propertyFromField(
     generator.context,
     field
   );
@@ -443,6 +444,7 @@ function propertyDeclarationForField(generator: CodeGenerator, field: Field) {
 
   generator.printNewlineIfNeeded();
   comment(generator, description);
+  deprecation(generator, isDeprecated, deprecationReason)
   generator.printOnNewline(`public var ${propertyName}: ${typeName}`);
   generator.withinBlock(() => {
     if (isCompositeType(namedType)) {
@@ -647,6 +649,7 @@ function enumerationDeclaration(generator: CodeGenerator, type: GraphQLEnumType)
   generator.withinBlock(() => {
     values.forEach(value => {
       comment(generator, value.description);
+      deprecation(generator, value.isDeprecated, value.deprecationReason)
       generator.printOnNewline(
         `case ${escapeIdentifierIfNeeded(enumCaseName(value.name))} = "${value.value}"`
       );

--- a/src/swift/language.ts
+++ b/src/swift/language.ts
@@ -9,6 +9,13 @@ export function comment(generator: CodeGenerator, comment: string | undefined) {
     });
 }
 
+export function deprecation(generator: CodeGenerator, isDeprecated: boolean | undefined, deprecationReason: string | undefined) {
+  if (isDeprecated !== undefined && isDeprecated) {
+    deprecationReason = (deprecationReason !== undefined && deprecationReason.length > 0) ? deprecationReason : ""
+    generator.printOnNewline(`@available(*, deprecated, message: "${deprecationReason}")`)
+  }
+}
+
 export function namespaceDeclaration(
   generator: CodeGenerator,
   namespace: string | undefined,


### PR DESCRIPTION
Swift only.  Apologies the issue was added to the appollo-ios repo.  If need be, I can create a ticket here, but I do feel it's reasonable as it's Swift specific.  Certainly open to any feedback on this. Cheers

Inserts deprecation code under code comment for properties if there's deprecation. 
uses: `__Field.isDeprecated` & `__Field.deprecationReason`
```
/// The categorization of this pie.
@available(*, deprecated, message: "Obsolete and will eventually be removed. Use the hierarchical `categorization` field instead.")
public var category: PieCategoryEnumType {
  get {
    return snapshot["category"]! as! PieCategoryEnumType
  }
  set {
    snapshot.updateValue(newValue, forKey: "category")
  }
}
```

Inserts deprecation code above the enum case if there's deprecation.
uses: `__EnumValue.isDeprecated` & `__EnumValue.deprecationReason`
```
/// A system pie status.
public enum SystemPieStatusEnum: String {
  /// Active
  @available(*, deprecated, message: "test active deprecation")
  case active = "ACTIVE"
  /// Inactive
  case inactive = "INACTIVE"
}
```
The two places graphQL allows deprecations can be seen here: https://facebook.github.io/graphql/#sec-Schema-Introspection

If no deprecation, nothing is added:
```
/// The name of this pie.
public var name: String {
  get {
    return snapshot["name"]! as! String
  }
  set {
    snapshot.updateValue(newValue, forKey: "name")
  }
}
```