### PR TITLE
Corrected example `__typename` usage in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ function CharacterFigures({ characters }: CharactersQuery) {
       case "Human":
         return <HumanFigure homePlanet={character.homePlanet} name={character.name} />
       case "Droid":
-        return <DroidFigure primaryFunction={character.homePlanet} name={character.name} />
+        return <DroidFigure primaryFunction={character.primaryFunction} name={character.name} />
     }
   });
 }


### PR DESCRIPTION
Just passing by… I found minor mistake in the example.