### PR TITLE
--passthroughCustomScalars option was not handled in Typescript generator

### DIFF
--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -312,7 +312,7 @@ export function propertyDeclarations(generator, properties, isInput = false) {
               }
             });
 
-            return propertiesFromFields(generator, fields);
+            return propertiesFromFields(generator.context, fields);
           } else {
             const fields = property.fields.map(field => {
               if (field.fieldName === '__typename') {

--- a/src/typescript/types.js
+++ b/src/typescript/types.js
@@ -5,8 +5,6 @@ import {
   indent
 } from '../utilities/printing';
 
-import { camelCase } from 'change-case';
-
 import {
   GraphQLString,
   GraphQLInt,

--- a/src/typescript/types.js
+++ b/src/typescript/types.js
@@ -36,7 +36,7 @@ export function typeNameFromGraphQLType(context, type, bareTypeName, nullable = 
   if (type instanceof GraphQLList) {
     typeName = `Array< ${typeNameFromGraphQLType(context, type.ofType, bareTypeName, true)} >`;
   } else if (type instanceof GraphQLScalarType) {
-    typeName = builtInScalarMap[type.name] || (context.passthroughCustomScalars ? context.customScalarsPrefix + type.name: builtInScalarMap[GraphQLString.name]);
+    typeName = builtInScalarMap[type.name] || (context.options.passthroughCustomScalars ? context.options.customScalarsPrefix + type.name: builtInScalarMap[GraphQLString.name]);
   } else {
     typeName = bareTypeName || type.name;
   }


### PR DESCRIPTION
This is fix for https://github.com/apollographql/apollo-codegen/issues/223