### PR TITLE
Flow code generation for scalar fields in document root

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -146,7 +146,7 @@ export function typeDeclarationForOperation(
 ) {
   const interfaceName = interfaceNameFromOperation({operationName, operationType});
   fields = fields.map(rootField => {
-    const fields = rootField.fields.map(field => {
+    const fields = rootField.fields && rootField.fields.map(field => {
       if (field.fieldName === '__typename') {
         return {
           ...field,

--- a/test/fixtures/misc/schema.graphql
+++ b/test/fixtures/misc/schema.graphql
@@ -52,6 +52,7 @@ type Query {
   commentTest: CommentTest
   interfaceTest: InterfaceTestCase
   unionTest: UnionTestCase
+  scalarTest: Boolean!
 }
 
 

--- a/test/fixtures/misc/schema.json
+++ b/test/fixtures/misc/schema.json
@@ -59,6 +59,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "scalarTest",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -301,6 +317,16 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -645,16 +671,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "The `Boolean` scalar type represents `true` or `false`.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -433,6 +433,15 @@ export type CustomScalarQuery = {|
 |};"
 `;
 
+exports[`Flow code generation #generateSource() should handle scalars at root 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type RootScalarQuery = {|
+  scalarTest: boolean,
+|};"
+`;
+
 exports[`Flow code generation #generateSource() should handle single line comments 1`] = `
 "/* @flow */
 //  This file was automatically generated and should not be edited.

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -292,5 +292,17 @@ describe('Flow code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should handle scalars at root', () => {
+      const { compileFromSource } = setup(miscSchema);
+      const context = compileFromSource(`
+        query RootScalar {
+          scalarTest
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Now it works. There was an exception when `rootField.fields` was `undefined`