### PR TITLE
Allow multiline comments in enums

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -73,9 +73,19 @@ function enumerationDeclaration(generator, type) {
   }
   generator.printOnNewline(`export type ${name} =`);
   const nValues = values.length;
-  values.forEach((value, i) =>
-    generator.printOnNewline(`  "${value.value}"${i === nValues-1 ? ';' : ' |'}${wrap(' // ', value.description)}`)
-  );
+  values.forEach((value, i) => {
+    if (!value.description || value.description.indexOf('\n') === -1) {
+      generator.printOnNewline(`  "${value.value}"${i === nValues - 1 ? ';' : ' |'}${wrap(' // ', value.description)}`)
+    } else {
+      if (value.description) {
+        value.description.split('\n')
+          .forEach(line => {
+            generator.printOnNewline(`  // ${line.trim()}`);
+          })
+      }
+      generator.printOnNewline(`  "${value.value}"${i === nValues - 1 ? ';' : ' |'}`)
+    }
+  });
   generator.printNewline();
 }
 

--- a/src/typescript/codeGeneration.ts
+++ b/src/typescript/codeGeneration.ts
@@ -75,9 +75,19 @@ function enumerationDeclaration(generator: CodeGenerator, type: GraphQLEnumType)
   }
   generator.printOnNewline(`export type ${name} =`);
   const nValues = values.length;
-  values.forEach((value, i) =>
-    generator.printOnNewline(`  "${value.value}"${i === nValues - 1 ? ';' : ' |'}${wrap(' // ', value.description)}`)
-  );
+  values.forEach((value, i) => {
+    if (!value.description || value.description.indexOf('\n') === -1) {
+      generator.printOnNewline(`  "${value.value}"${i === nValues - 1 ? ';' : ' |'}${wrap(' // ', value.description)}`)
+    } else {
+      if (value.description) {
+        value.description.split('\n')
+          .forEach(line => {
+            generator.printOnNewline(`  // ${line.trim()}`);
+          })
+      }
+      generator.printOnNewline(`  "${value.value}"${i === nValues - 1 ? ';' : ' |'}`)
+    }
+  });
   generator.printNewline();
 }
 

--- a/test/fixtures/misc/schema.graphql
+++ b/test/fixtures/misc/schema.graphql
@@ -21,6 +21,15 @@ type CommentTest {
   # This is a multi-line
   # comment.
   multiLine: String
+  enumCommentTest: EnumCommentTestCase
+}
+
+enum EnumCommentTestCase {
+  # This is a single-line comment
+  first
+  # This is a multi-line
+  # comment.
+  second
 }
 
 interface InterfaceTestCase {
@@ -53,5 +62,3 @@ type Query {
   interfaceTest: InterfaceTestCase
   unionTest: UnionTestCase
 }
-
-

--- a/test/fixtures/misc/schema.json
+++ b/test/fixtures/misc/schema.json
@@ -184,11 +184,46 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "enumCommentTest",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "EnumCommentTestCase",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EnumCommentTestCase",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "first",
+              "description": "This is a single-line comment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "second",
+              "description": "This is a multi-line\ncomment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -401,6 +401,25 @@ export type HeroNameQuery = {|
 |};"
 `;
 
+exports[`Flow code generation #generateSource() should handle comments in enums 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type EnumCommentTestCase =
+  \\"first\\" | // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  \\"second\\";
+
+
+export type CustomScalarQuery = {|
+  commentTest: ? {|
+    __typename: \\"CommentTest\\",
+    enumCommentTest: ?EnumCommentTestCase,
+  |},
+|};"
+`;
+
 exports[`Flow code generation #generateSource() should handle interfaces at root 1`] = `
 "/* @flow */
 //  This file was automatically generated and should not be edited.

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -254,6 +254,20 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
+    test('should handle comments in enums', () => {
+      const { compileFromSource } = setup(miscSchema);
+      const context = compileFromSource(`
+        query CustomScalar {
+          commentTest {
+            enumCommentTest
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
     test('should handle interfaces at root', () => {
       const { compileFromSource } = setup(miscSchema);
       const context = compileFromSource(`

--- a/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -332,6 +332,27 @@ export type HeroNameQuery = {
 "
 `;
 
+exports[`TypeScript code generation #generateSource() should handle comments in enums 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type EnumCommentTestCase =
+  \\"first\\" | // This is a single-line comment
+  // This is a multi-line
+  // comment.
+  \\"second\\";
+
+
+export type CustomScalarQuery = {
+  commentTest:  {
+    __typename: \\"CommentTest\\",
+    enumCommentTest: EnumCommentTestCase | null,
+  } | null,
+};
+/* tslint:enable */
+"
+`;
+
 exports[`TypeScript code generation #generateSource() should handle interfaces at root 1`] = `
 "/* tslint:disable */
 //  This file was automatically generated and should not be edited.

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -223,6 +223,20 @@ describe('TypeScript code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
+    test('should handle comments in enums', () => {
+      const { compileFromSource } = setup(miscSchema);
+      const context = compileFromSource(`
+        query CustomScalar {
+          commentTest {
+            enumCommentTest
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
     test('should handle interfaces at root', () => {
       const { compileFromSource } = setup(miscSchema);
       const context = compileFromSource(`


### PR DESCRIPTION
Before, multiline comments were printed correctly only in record types.