### PR TITLE
[Swift] Fix output not compiling when using --namespace with enums

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -581,7 +581,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
     this.printNewlineIfNeeded();
     this.comment(description);
-    this.printOnNewline(`public enum ${name}: String`);
+    this.printOnNewline(`public enum ${name}: String, Apollo.JSONDecodable, Apollo.JSONEncodable`);
     this.withinBlock(() => {
       values.forEach(value => {
         this.comment(value.description);
@@ -590,8 +590,6 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         );
       });
     });
-    this.printNewline();
-    this.printOnNewline(`extension ${name}: Apollo.JSONDecodable, Apollo.JSONEncodable {}`);
   }
 
   structDeclarationForInputObjectType(type: GraphQLInputObjectType) {

--- a/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1313,12 +1313,10 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
-"public enum AlbumPrivacies: String {
+"public enum AlbumPrivacies: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   case \`public\` = \\"PUBLIC\\"
   case \`private\` = \\"PRIVATE\\"
-}
-
-extension AlbumPrivacies: Apollo.JSONDecodable, Apollo.JSONEncodable {}"
+}"
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate a struct declaration for a GraphQLInputObjectType 1`] = `
@@ -1364,14 +1362,12 @@ public struct ReviewInput: GraphQLMapConvertible {
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
-public enum Episode: String {
+public enum Episode: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   /// Star Wars Episode IV: A New Hope, released in 1977.
   case newhope = \\"NEWHOPE\\"
   /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
   case empire = \\"EMPIRE\\"
   /// Star Wars Episode VI: Return of the Jedi, released in 1983.
   case jedi = \\"JEDI\\"
-}
-
-extension Episode: Apollo.JSONDecodable, Apollo.JSONEncodable {}"
+}"
 `;


### PR DESCRIPTION
Conforming to Apollo.JSONDecodable/Encodable by `extension` on enum types does not compile when wrapping the generated output in a namespace (`--namespace <Namespace>` CLI flag), since Swift does not allow extensions from within a nested scope.

Before this patch, generated output (with namespace) would look like this:

```swift
public enum WhateverNamespace {
  public enum CaseCategory: String {
    // …
  }

  extension CaseCategory: Apollo.JSONDecodable, Apollo.JSONEncodable {}
  // ^ Compiler error: Declaration is only valid at file scope
}
```

After this patch, it'll be something more along these lines:

```swift
public enum WhateverNamespace {
  public enum CaseCategory: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
    // …
  }
}
```