### PR TITLE
Correct typename values for fragments on non-abstract types

### DIFF
--- a/src/typescript/codeGeneration.ts
+++ b/src/typescript/codeGeneration.ts
@@ -258,7 +258,19 @@ export function interfaceDeclarationForFragment(
 
       propertySetsDeclaration(generator, fragment, propertySets, true);
     } else {
-      const properties = propertiesFromFields(generator.context, fields)
+      const fragmentFields = fields.map(field => {
+        if (field.fieldName === '__typename') {
+          return {
+            ...field,
+            typeName: `"${fragment.typeCondition}"`,
+            type: { name: `"${fragment.typeCondition}"` } as GraphQLType
+          }
+        } else {
+          return field;
+        }
+      });
+
+      const properties = propertiesFromFields(generator.context, fragmentFields)
       propertyDeclarations(generator, properties);
     }
   });

--- a/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -421,3 +421,55 @@ export type CustomScalarQuery = {
 /* tslint:enable */
 "
 `;
+
+exports[`TypeScript code generation #generateSource() should have __typename value matching fragment type on generic type 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type HeroNameQuery = {
+  hero: ( {
+      __typename: \\"Human\\",
+      // The name of the character
+      name: string,
+    } | {
+      __typename: \\"Droid\\",
+      // The name of the character
+      name: string,
+    }
+  ) | null,
+};
+
+export type HeroWithNameFragment = ( {
+      __typename: \\"Human\\",
+      // The name of the character
+      name: string,
+    } | {
+      __typename: \\"Droid\\",
+      // The name of the character
+      name: string,
+    }
+  );
+/* tslint:enable */
+"
+`;
+
+exports[`TypeScript code generation #generateSource() should have __typename value matching fragment type on specific type 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type DroidNameQuery = {
+  droid:  {
+    __typename: \\"Droid\\",
+    // What others call this droid
+    name: string,
+  } | null,
+};
+
+export type DroidWithNameFragment = {
+  __typename: \\"Droid\\",
+  // What others call this droid
+  name: string,
+};
+/* tslint:enable */
+"
+`;

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -275,5 +275,43 @@ describe('TypeScript code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test('should have __typename value matching fragment type on generic type', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query HeroName {
+          hero {
+            ...HeroWithName
+          }
+        }
+
+        fragment HeroWithName on Character {
+          __typename
+          name
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
+    test('should have __typename value matching fragment type on specific type', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query DroidName {
+          droid {
+            ...DroidWithName
+          }
+        }
+
+        fragment DroidWithName on Droid {
+          __typename
+          name
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Previously `__typename: string` was generated for cases like `DroidWithName` in the tests.