### PR TITLE
Update Jest Typescript support to use ts-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "common-tags": "^1.4.0",
     "jest": "^21.1.0",
     "jest-matcher-utils": "^21.1.0",
+    "ts-jest": "^21.0.1",
     "typescript": "^2.5.2"
   },
   "dependencies": {
@@ -64,7 +65,7 @@
       "<rootDir>/test/test-utils"
     ],
     "transform": {
-      ".(js|ts)": "<rootDir>/test/test-utils/preprocessor.js"
+      "^.+\\.(ts|js)x?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "moduleFileExtensions": [
       "ts",

--- a/test/test-utils/preprocessor.js
+++ b/test/test-utils/preprocessor.js
@@ -1,8 +1,0 @@
-const tsc = require('typescript');
-const tsConfig = require('../tsconfig.json');
-
-module.exports = {
-  process(src, path) {
-    return tsc.transpile(src, tsConfig.compilerOptions, path, []);
-  }
-};


### PR DESCRIPTION
Was running into problems finding the right source when errors / logs are reported within tests so I decided to try fixing sourcemaps. Seems like using ts-jest instead of our custom preprocessor fixes it