### PR TITLE
Fix __typename for List types in Flow

### DIFF
--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -12,6 +12,19 @@ export type CustomScalarQuery = {|
 |};"
 `;
 
+exports[`Flow code generation #generateSource() should generate array query operations 1`] = `
+"/* @flow */
+//  This file was automatically generated and should not be edited.
+
+export type ReviewsStarsQuery = {|
+  reviews: ? Array<? {|
+    __typename: \\"undefined\\",
+    // The number of stars this review gave, 1-5
+    stars: number,
+  |} >,
+|};"
+`;
+
 exports[`Flow code generation #generateSource() should generate correct typedefs with a multiple custom fragments 1`] = `
 "/* @flow */
 //  This file was automatically generated and should not be edited.

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -18,7 +18,7 @@ exports[`Flow code generation #generateSource() should generate array query oper
 
 export type ReviewsStarsQuery = {|
   reviews: ? Array<? {|
-    __typename: \\"undefined\\",
+    __typename: \\"Review\\",
     // The number of stars this review gave, 1-5
     stars: number,
   |} >,

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -91,6 +91,20 @@ describe('Flow code generation', function() {
       expect(source).toMatchSnapshot();
     });
 
+    test(`should generate array query operations`, function() {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query ReviewsStars {
+          reviews {
+            stars
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
     test(`should generate simple nested with required elements in lists`, function() {
       const { compileFromSource } = setup(starWarsSchema);
       const context = compileFromSource(`


### PR DESCRIPTION
I noticed that I sometimes got `__typename: "undefined"` when generating Flow code. It didn't seem to happen in TypeScript. I compared the TypeScript and Flow implementations and copied some things over from TypeScript and managed to fix the bug!

Schema:

```graphql
schema {
  query: Query
}

type Query {
  persons: [Person]
}

type Person {
  name: String
}
```

Query:

```graphql
query Test {
  persons {
    name
  }
}
```

Generated Flow code, before:

```js
export type TestQuery = {|
  persons: ? Array<? {|
    __typename: "undefined", // NOTE THE "undefined"!
    name: ?string,
  |} >,
|};
```

Generated Flow code, after:

```js
export type TestQuery = {|
  persons: ? Array<? {|
    __typename: "Person", // Yay!
    name: ?string,
  |} >,
|};
```