### PR TITLE
disable ESLint when generating Flow types

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -39,6 +39,7 @@ export function generateSource(context) {
   const generator = new CodeGenerator(context);
 
   generator.printOnNewline('/* @flow */');
+  generator.printOnNewline('/* eslint-disable */');
   generator.printOnNewline('//  This file was automatically generated and should not be edited.');
   typeDeclarationForGraphQLType(context.typesUsed.forEach(type =>
     typeDeclarationForGraphQLType(generator, type)


### PR DESCRIPTION
when generating Typescript, `tslint:disable` is added to the top of the generated file. ESLint should be disabled for Flow in the same way.