### PR TITLE
Flow: add 'unsealed-objects' option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -143,6 +143,11 @@ yargs
         describe: "For non-swift targets, always add the __typename GraphQL introspection type when generating target types",
         default: false
       },
+      "unsealed-objects": {
+        demand: false,
+        describe: "Generate unsealed object typed [Flow only]",
+        default: false
+      },
       "tag-name": {
         demand: false,
         describe: "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
@@ -182,6 +187,7 @@ yargs
         passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] !== '',
         customScalarsPrefix: argv["custom-scalars-prefix"] || '',
         addTypename: argv["add-typename"],
+        unsealedObjects: argv["unsealed-objects"],
         namespace: argv.namespace,
         operationIdsPath: argv["operation-ids-path"],
         generateOperationIds: !!argv["operation-ids-path"],

--- a/src/flow/language.js
+++ b/src/flow/language.js
@@ -16,7 +16,10 @@ export function typeDeclaration(generator, { interfaceName, noBrackets }, closur
   if (noBrackets) {
     generator.withinBlock(closure, '', '');
   } else {
-    generator.withinBlock(closure, '{|', '|}');
+    const { unsealedObjects } = generator.context.options;
+    const open = unsealedObjects ? '{' : '{|';
+    const close = unsealedObjects ? '}' : '|}';
+    generator.withinBlock(closure, open, close);
   }
   generator.popScope();
   generator.print(';');
@@ -33,7 +36,10 @@ export function propertyDeclaration(generator, {
   isArrayElementNullable,
   fragmentSpreads,
   isInput
-}, closure, open = ' {|', close = '|}') {
+}, closure, open_, close_) {
+  const { unsealedObjects } = generator.context.options;
+  const open = open_ || (unsealedObjects ? ' {' : ' {|');
+  const close = close_ || (unsealedObjects ? '}' : '|}');
   const name = fieldName || propertyName;
 
   if (description) {


### PR DESCRIPTION
After using Flow in real projects for around a year, I strongly prefer using unsealed objects almost all the time. Exact objects bring a lot more pain in the nether regions for only a modest amount of type safety. So IMO they are not worth it.

This PR only adds an option and should not influence anyone who is not using it.