### PR TITLE
Swift Support Unknown Enums

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -741,6 +741,23 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           `case ${escapeIdentifierIfNeeded(this.helpers.enumCaseName(value.name))} = "${value.value}"`
         );
       });
+
+      this.comment('Auto generated constant for unknown enum values');
+      this.printOnNewline('case unknown');
+
+      this.printNewlineIfNeeded();
+      this.printOnNewline('public init(jsonValue value: JSONValue) throws');
+      this.withinBlock(() => {
+        this.printOnNewline('let rawValue = try RawValue(jsonValue: value)');
+        this.printOnNewline(`if let tempSelf = ${name}(rawValue: rawValue)`);
+        this.withinBlock(() => {
+            this.printOnNewline('self = tempSelf');
+        });
+        this.printOnNewline('else');
+        this.withinBlock(() => {
+          this.printOnNewline('self = .unknown');
+        });
+      });
     });
   }
 

--- a/src/swift/helpers.ts
+++ b/src/swift/helpers.ts
@@ -88,6 +88,10 @@ export class Helpers {
     return camelCase(name);
   }
 
+  enumDotCaseName(name: string) {
+    return `.${camelCase(name)}`;
+  }
+
   operationClassName(name: string) {
     return pascalCase(name);
   }

--- a/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1430,6 +1430,18 @@ exports[`Swift code generation #typeDeclarationForGraphQLType() should escape id
 "public enum AlbumPrivacies: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   case \`public\` = \\"PUBLIC\\"
   case \`private\` = \\"PRIVATE\\"
+  /// Auto generated constant for unknown enum values
+  case unknown
+
+  public init(jsonValue value: JSONValue) throws {
+    let rawValue = try RawValue(jsonValue: value)
+    if let tempSelf = AlbumPrivacies(rawValue: rawValue) {
+      self = tempSelf
+    }
+    else {
+      self = .unknown
+    }
+  }
 }"
 `;
 
@@ -1483,5 +1495,17 @@ public enum Episode: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   case empire = \\"EMPIRE\\"
   /// Star Wars Episode VI: Return of the Jedi, released in 1983.
   case jedi = \\"JEDI\\"
+  /// Auto generated constant for unknown enum values
+  case unknown
+
+  public init(jsonValue value: JSONValue) throws {
+    let rawValue = try RawValue(jsonValue: value)
+    if let tempSelf = Episode(rawValue: rawValue) {
+      self = tempSelf
+    }
+    else {
+      self = .unknown
+    }
+  }
 }"
 `;

--- a/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1427,19 +1427,35 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
-"public enum AlbumPrivacies: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
-  case \`public\` = \\"PUBLIC\\"
-  case \`private\` = \\"PRIVATE\\"
+"public enum AlbumPrivacies: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+  public typealias RawValue = String
+  case \`public\`
+  case \`private\`
   /// Auto generated constant for unknown enum values
-  case unknown
+  case unknown(RawValue)
 
-  public init(jsonValue value: JSONValue) throws {
-    let rawValue = try RawValue(jsonValue: value)
-    if let tempSelf = AlbumPrivacies(rawValue: rawValue) {
-      self = tempSelf
+  public init?(rawValue: RawValue) {
+    switch rawValue {
+      case \\"PUBLIC\\": self = .public
+      case \\"PRIVATE\\": self = .private
+      default: self = .unknown(rawValue)
     }
-    else {
-      self = .unknown
+  }
+
+  public var rawValue: RawValue {
+    switch self {
+      case .public: return \\"PUBLIC\\"
+      case .private: return \\"PRIVATE\\"
+      case .unknown(let value): return value
+    }
+  }
+
+  public static func == (lhs: AlbumPrivacies, rhs: AlbumPrivacies) -> Bool {
+    switch (lhs, rhs) {
+      case (.public, .public): return true
+      case (.private, .private): return true
+      case (.unknown(let lhsValue), .unknown(let rhsValue)): return lhsValue == rhsValue
+      default: return false
     }
   }
 }"
@@ -1488,23 +1504,42 @@ public struct ReviewInput: GraphQLMapConvertible {
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
-public enum Episode: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum Episode: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+  public typealias RawValue = String
   /// Star Wars Episode IV: A New Hope, released in 1977.
-  case newhope = \\"NEWHOPE\\"
+  case newhope
   /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
-  case empire = \\"EMPIRE\\"
+  case empire
   /// Star Wars Episode VI: Return of the Jedi, released in 1983.
-  case jedi = \\"JEDI\\"
+  case jedi
   /// Auto generated constant for unknown enum values
-  case unknown
+  case unknown(RawValue)
 
-  public init(jsonValue value: JSONValue) throws {
-    let rawValue = try RawValue(jsonValue: value)
-    if let tempSelf = Episode(rawValue: rawValue) {
-      self = tempSelf
+  public init?(rawValue: RawValue) {
+    switch rawValue {
+      case \\"NEWHOPE\\": self = .newhope
+      case \\"EMPIRE\\": self = .empire
+      case \\"JEDI\\": self = .jedi
+      default: self = .unknown(rawValue)
     }
-    else {
-      self = .unknown
+  }
+
+  public var rawValue: RawValue {
+    switch self {
+      case .newhope: return \\"NEWHOPE\\"
+      case .empire: return \\"EMPIRE\\"
+      case .jedi: return \\"JEDI\\"
+      case .unknown(let value): return value
+    }
+  }
+
+  public static func == (lhs: Episode, rhs: Episode) -> Bool {
+    switch (lhs, rhs) {
+      case (.newhope, .newhope): return true
+      case (.empire, .empire): return true
+      case (.jedi, .jedi): return true
+      case (.unknown(let lhsValue), .unknown(let rhsValue)): return lhsValue == rhsValue
+      default: return false
     }
   }
 }"


### PR DESCRIPTION
This PR addresses the issue presented in #284.  

* Update generated enums to implement `RawRepresentable` protocol directly so that we can wrap the unknown value received from the server and echo it back on encoding.  This allows clients to use the `.unknown` enum case and actually use the value they received from the server if they choose to do so.
* Implement `Equatable` protocol on Enum to allow for `XCTAssertEqual` to work properly.