### PR TITLE
Escaping struct names

### DIFF
--- a/src/swift/language.ts
+++ b/src/swift/language.ts
@@ -117,7 +117,7 @@ export class SwiftGenerator<Context> extends CodeGenerator<Context, { typeName: 
   structDeclaration({ structName, description, adoptedProtocols = [] }: Struct, closure: Function) {
     this.printNewlineIfNeeded();
     this.comment(description);
-    this.printOnNewline(`public struct ${structName}`);
+    this.printOnNewline(`public struct ${escapeIdentifierIfNeeded(structName)}`);
     this.print(wrap(': ', join(adoptedProtocols, ', ')));
     this.pushScope({ typeName: structName });
     this.withinBlock(closure);

--- a/test/swift/language.ts
+++ b/test/swift/language.ts
@@ -39,6 +39,20 @@ describe('Swift code generation: Basic language constructs', () => {
     `);
   });
 
+  it(`should generate an escaped struct declaration`, () => {
+    generator.structDeclaration({ structName: 'Type' }, () => {
+      generator.propertyDeclaration({ propertyName: 'name', typeName: 'String' });
+      generator.propertyDeclaration({ propertyName: 'yearOfBirth', typeName: 'Int' });
+    });
+
+    expect(generator.output).toBe(stripIndent`
+      public struct \`Type\` {
+        public var name: String
+        public var yearOfBirth: Int
+      }
+    `);
+  });
+
   it(`should generate nested struct declarations`, () => {
     generator.structDeclaration({ structName: 'Hero' }, () => {
       generator.propertyDeclaration({ propertyName: 'name', typeName: 'String' });


### PR DESCRIPTION
This isn't ready to merge, but I wanted to run it by you for a second set of eyes. The issue is that if I have a SelectionSet that asks for a field named `type` it generates a Swift struct with,

```swift
public struct Type: GraphQLSelectionSet
```

But `Type` there is a reserved word and needs to be escaped. This change runs all structs through the escaping function so the above issue doesn't happen any more.