### PR TITLE
Flow: Correct typename values for fragments on non-abstract types

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -261,7 +261,18 @@ export function typeDeclarationForFragment(
 
       propertySetsDeclaration(generator, fragment, propertySets, true);
     } else {
-      const properties = propertiesFromFields(generator.context, fields)
+      const fragmentFields = fields.map(field => {
+        if (field.fieldName === '__typename') {
+          return {
+            ...field,
+            typeName: `"${fragment.typeCondition}"`,
+            type: { name: `"${fragment.typeCondition}"` }
+          }
+        } else {
+          return field;
+        }
+      });
+      const properties = propertiesFromFields(generator.context, fragmentFields)
       propertyDeclarations(generator, properties);
     }
   });

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -519,3 +519,53 @@ export type CustomScalarQuery = {|
   ),
 |};"
 `;
+
+exports[`Flow code generation #generateSource() should have __typename value matching fragment type on generic type 1`] = `
+"/* @flow */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+
+export type HeroNameQuery = {|
+  hero: ?( {
+      __typename: \\"Human\\",
+      // The name of the character
+      name: string,
+    } | {
+      __typename: \\"Droid\\",
+      // The name of the character
+      name: string,
+    }
+  ),
+|};
+
+export type HeroWithNameFragment = ( {
+      __typename: \\"Human\\",
+      // The name of the character
+      name: string,
+    } | {
+      __typename: \\"Droid\\",
+      // The name of the character
+      name: string,
+    }
+  );"
+`;
+
+exports[`Flow code generation #generateSource() should have __typename value matching fragment type on specific type 1`] = `
+"/* @flow */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+
+export type DroidNameQuery = {|
+  droid: ? {|
+    __typename: \\"Droid\\",
+    // What others call this droid
+    name: string,
+  |},
+|};
+
+export type DroidWithNameFragment = {|
+  __typename: \\"Droid\\",
+  // What others call this droid
+  name: string,
+|};"
+`;

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -332,5 +332,43 @@ describe('Flow code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+    
+    test('should have __typename value matching fragment type on generic type', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query HeroName {
+          hero {
+            ...HeroWithName
+          }
+        }
+
+        fragment HeroWithName on Character {
+          __typename
+          name
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
+
+    test('should have __typename value matching fragment type on specific type', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query DroidName {
+          droid {
+            ...DroidWithName
+          }
+        }
+
+        fragment DroidWithName on Droid {
+          __typename
+          name
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
This PR just ports https://github.com/apollographql/apollo-codegen/pull/251 from Typescript to Flow.