### PR TITLE
 Add typeName for nested property objects

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -370,7 +370,19 @@ export function propertyDeclarations(generator, properties, isInput) {
         || property.fragmentSpreads && property.fragmentSpreads.length > 0
       ) {
         propertyDeclaration(generator, property, () => {
-          const properties = propertiesFromFields(generator.context, property.fields);
+          const fields = property.fields.map(field => {
+            if (field.fieldName === '__typename') {
+              const objectTypeName = getObjectTypeName(property.fieldType || property.type);
+              return {
+                ...field,
+                typeName: objectTypeName,
+                type: { name: objectTypeName }
+              }
+            } else {
+              return field;
+            }
+          });
+          const properties = propertiesFromFields(generator.context, fields);
           propertyDeclarations(generator, properties, isInput);
         });
       } else {

--- a/src/typescript/codeGeneration.ts
+++ b/src/typescript/codeGeneration.ts
@@ -391,7 +391,19 @@ export function propertyDeclarations(generator: CodeGenerator, properties: Prope
         || property.fragmentSpreads && property.fragmentSpreads.length > 0
       ) {
         propertyDeclaration(generator, property, () => {
-          const properties = propertiesFromFields(generator.context, property.fields!);
+          const fields = property.fields.map(field => {
+            if (field.fieldName === '__typename') {
+              const objectTypeName = getObjectTypeName(property.fieldType || property.type);
+              return {
+                ...field,
+                typeName: objectTypeName,
+                type: { name: objectTypeName }
+              }
+            } else {
+              return field;
+            }
+          });
+          const properties = propertiesFromFields(generator.context, fields!);
           propertyDeclarations(generator, properties, isInput);
         });
       } else {

--- a/test/flow/__snapshots__/codeGeneration.js.snap
+++ b/test/flow/__snapshots__/codeGeneration.js.snap
@@ -520,6 +520,65 @@ export type CustomScalarQuery = {|
 |};"
 `;
 
+exports[`Flow code generation #generateSource() should have __typename value in nested property 1`] = `
+"/* @flow */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+
+export type HeroNameQuery = {|
+  hero: ?( {
+      __typename: \\"Human\\",
+      // The friends of the human exposed as a connection with edges
+      friendsConnection: {|
+        __typename: \\"FriendsConnection\\",
+        // The edges for each of the character's friends.
+        edges: ? Array<? {|
+          __typename: \\"FriendsEdge\\",
+          // The character represented by this friendship edge
+          node: ?( {
+              __typename: \\"Human\\",
+              // The name of the character
+              name: string,
+            } | {
+              __typename: \\"Droid\\",
+              // The name of the character
+              name: string,
+            }
+          ),
+        |} >,
+      |},
+      // A list of starships this person has piloted, or an empty list if none
+      starships: ? Array<? {|
+        __typename: \\"Starship\\",
+        // The name of the starship
+        name: string,
+      |} >,
+    } | {
+      __typename: \\"Droid\\",
+      // The friends of the character exposed as a connection with edges
+      friendsConnection: {|
+        __typename: \\"FriendsConnection\\",
+        // The edges for each of the character's friends.
+        edges: ? Array<? {|
+          __typename: \\"FriendsEdge\\",
+          // The character represented by this friendship edge
+          node: ?( {
+              __typename: \\"Human\\",
+              // The name of the character
+              name: string,
+            } | {
+              __typename: \\"Droid\\",
+              // The name of the character
+              name: string,
+            }
+          ),
+        |} >,
+      |},
+    }
+  ),
+|};"
+`;
+
 exports[`Flow code generation #generateSource() should have __typename value matching fragment type on generic type 1`] = `
 "/* @flow */
 /* eslint-disable */

--- a/test/flow/codeGeneration.js
+++ b/test/flow/codeGeneration.js
@@ -370,5 +370,31 @@ describe('Flow code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+    
+    test('should have __typename value in nested property', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query HeroName {
+          hero {
+            friendsConnection {
+              edges {
+                node {
+                  name
+                  
+                }
+              }
+            }
+            ... on Human {
+              starships {
+                name
+              }
+            }
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });

--- a/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -414,6 +414,65 @@ export type CustomScalarQuery = {
 "
 `;
 
+exports[`TypeScript code generation #generateSource() should have __typename value in nested property 1`] = `
+"/* tslint:disable */
+//  This file was automatically generated and should not be edited.
+
+export type HeroNameQuery = {
+  hero: ( {
+      __typename: \\"Human\\",
+      // The friends of the human exposed as a connection with edges
+      friendsConnection:  {
+        __typename: \\"FriendsConnection\\",
+        // The edges for each of the character's friends.
+        edges:  Array< {
+          __typename: \\"FriendsEdge\\",
+          // The character represented by this friendship edge
+          node: ( {
+              __typename: \\"Human\\",
+              // The name of the character
+              name: string,
+            } | {
+              __typename: \\"Droid\\",
+              // The name of the character
+              name: string,
+            }
+          ) | null,
+        } | null > | null,
+      },
+      // A list of starships this person has piloted, or an empty list if none
+      starships:  Array< {
+        __typename: \\"Starship\\",
+        // The name of the starship
+        name: string,
+      } | null > | null,
+    } | {
+      __typename: \\"Droid\\",
+      // The friends of the character exposed as a connection with edges
+      friendsConnection:  {
+        __typename: \\"FriendsConnection\\",
+        // The edges for each of the character's friends.
+        edges:  Array< {
+          __typename: \\"FriendsEdge\\",
+          // The character represented by this friendship edge
+          node: ( {
+              __typename: \\"Human\\",
+              // The name of the character
+              name: string,
+            } | {
+              __typename: \\"Droid\\",
+              // The name of the character
+              name: string,
+            }
+          ) | null,
+        } | null > | null,
+      },
+    }
+  ) | null,
+};
+"
+`;
+
 exports[`TypeScript code generation #generateSource() should have __typename value matching fragment type on generic type 1`] = `
 "/* tslint:disable */
 //  This file was automatically generated and should not be edited.

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -313,5 +313,31 @@ describe('TypeScript code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+    
+    test('should have __typename value in nested property', () => {
+      const { compileFromSource } = setup(starWarsSchema);
+      const context = compileFromSource(`
+        query HeroName {
+          hero {
+            friendsConnection {
+              edges {
+                node {
+                  name
+                  
+                }
+              }
+            }
+            ... on Human {
+              starships {
+                name
+              }
+            }
+          }
+        }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Fix the issue that nested property objects has `__typename: string`.

Before:
```js
{
  __typename: "Human",
  friendsConnection: {|
    ___typename: string,
    edges: ? Array<? {|
      __typename: string,
      node: ?( {
          __typename: "Human",
          name: string,
        } | {
          __typename: "Droid",
          name: string,
        }
      ),
    |} >,
  |},
  starships: ? Array<? {|
    __typename: string,
    name: string,
  |} >,
}
```

After:
```js
{
  __typename: "Human",
  friendsConnection: {|
    __typename: "FriendsConnection",
    edges: ? Array<? {|
      __typename: "FriendsEdge",
      node: ?( {
          __typename: "Human",
          name: string,
        } | {
          __typename: "Droid",
          name: string,
        }
      ),
    |} >,
  |},
  starships: ? Array<? {|
    __typename: "Starship",
    name: string,
  |} >,
}
```
