### PR TITLE
Flow: handle multiline comments in GraphQL schema

### DIFF
--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -252,6 +252,41 @@ export type Episode = \\"NEWHOPE\\" | \\"EMPIRE\\" | \\"JEDI\\";
 }
 `;
 
+exports[`Flow codeGeneration handles multiline graphql comments 1`] = `
+Object {
+  "__generated__/CustomScalar.js": FlowGeneratedFile {
+    "fileContents": "
+
+/* @flow */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CustomScalar
+// ====================================================
+
+export type CustomScalar_commentTest = {
+  __typename: \\"CommentTest\\",
+  multiLine: ?string, // This is a multi-line comment.
+};
+
+export type CustomScalar = {
+  commentTest: ?CustomScalar_commentTest
+};
+
+//==============================================================
+// START Enums and Input Objects
+// All enums and input objects are included in every output file
+// for now, but this will be changed soon.
+// TODO: Link to issue to fix this.
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  },
+}
+`;
+
 exports[`Flow codeGeneration inline fragment 1`] = `
 Object {
   "__generated__/HeroInlineFragment.js": FlowGeneratedFile {

--- a/src/javascript/flow/__tests__/codeGeneration.ts
+++ b/src/javascript/flow/__tests__/codeGeneration.ts
@@ -254,4 +254,25 @@ describe('Flow codeGeneration', () => {
     const output = generateSource(context);
     expect(output).toMatchSnapshot();
   });
+
+  test('handles multiline graphql comments', () => {
+    const miscSchema = loadSchema(require.resolve('../../../../test/fixtures/misc/schema.json'));
+
+    const document = parse(`
+      query CustomScalar {
+        commentTest {
+          multiLine
+        }
+      }
+    `);
+
+    const output = generateSource(
+      compileToIR(miscSchema, document, {
+        mergeInFieldsFromFragmentSpreads: true,
+        addTypename: true
+      })
+    );
+
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/src/javascript/flow/language.ts
+++ b/src/javascript/flow/language.ts
@@ -74,10 +74,12 @@ export default class FlowGenerator {
       keyInheritsNullability: true
     });
 
-    typeAlias.leadingComments = [{
-      type: 'CommentLine',
-      value: ` ${description}`
-    } as t.CommentLine]
+    if (description) {
+      typeAlias.leadingComments = [{
+        type: 'CommentLine',
+        value: ` ${description.replace('\n', ' ')}`
+      } as t.CommentLine]
+    }
 
     return typeAlias;
   }
@@ -104,7 +106,7 @@ export default class FlowGenerator {
         if (description) {
           objectTypeProperty.trailingComments = [{
             type: 'CommentLine',
-            value: ` ${description}`
+            value: ` ${description.replace('\n', ' ')}`
           } as t.CommentLine]
         }
 

--- a/src/javascript/flow/printer.ts
+++ b/src/javascript/flow/printer.ts
@@ -78,7 +78,7 @@ export default class Printer {
         const [contents, comment] = currentLineContents.split('//');
         newDocumentParts.push({
           main: contents.replace(/\s+$/g, '') + ',',
-          comment: comment.trim()
+          comment: comment ? comment.trim() : null
         });
         currentLine++;
       } else {


### PR DESCRIPTION
Fixes #306

Just print everything on the same line for now to unbreak output.
Modifications to make the output prettier will come later