### PR TITLE
Use npm@5 for all versions of node in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 
 before_install:
   - npm install -g npm@5
+  - npm --version
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ cache:
   directories:
     - $HOME/.npm
 
+before_install:
+  - npm install -g npm@5
+
 install:
   - npm install
 

--- a/src/javascript/typescript/printer.ts
+++ b/src/javascript/typescript/printer.ts
@@ -107,6 +107,7 @@ export default class Printer {
           line = `${main}${' '.repeat(spacesBetween)} // ${comment.trim()}`
         } else {
           line = main;
+        }
 
         return [
           ...memo,


### PR DESCRIPTION
Take advantage of package-lock for tests. Otherwise we'd be installing different versions of things :(