### PR TITLE
Generate using TS node types in Typescript Modern

### DIFF
--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -12,26 +12,34 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
+export interface HeroName_hero_Human_friends_Human {
   __typename: \\"Human\\";
   name: string;  // What this human calls themselves
-} | {
-  __typename: \\"Droid\\";
-  id: string;    // The ID of the droid
-};
+}
 
-export type HeroName_hero = {
+export interface HeroName_hero_Human_friends_Droid {
+  __typename: \\"Droid\\";
+  id: string;  // The ID of the droid
+}
+
+export type HeroName_hero_Human_friends = HeroName_hero_Human_friends_Human | HeroName_hero_Human_friends_Droid;
+
+export interface HeroName_hero_Human {
   __typename: \\"Human\\";
   name: string;                                            // What this human calls themselves
   id: string;                                              // The ID of the human
   homePlanet: string | null;                               // The home planet of the human, or null if unknown
   friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
-} | {
+}
+
+export interface HeroName_hero_Droid {
   __typename: \\"Droid\\";
-  name: string;                                            // What others call this droid
-  id: string;                                              // The ID of the droid
-  appearsIn: (Episode | null)[];                           // The movies this droid appears in
-};
+  name: string;                   // What others call this droid
+  id: string;                     // The ID of the droid
+  appearsIn: (Episode | null)[];  // The movies this droid appears in
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
 
 export interface HeroName {
   hero: HeroName_hero | null;
@@ -98,13 +106,17 @@ export enum Episode {
 // GraphQL fragment: humanFragment
 // ====================================================
 
-export type humanFragment_friends = {
+export interface humanFragment_friends_Human {
   __typename: \\"Human\\";
   name: string;  // What this human calls themselves
-} | {
+}
+
+export interface humanFragment_friends_Droid {
   __typename: \\"Droid\\";
-  id: string;    // The ID of the droid
-};
+  id: string;  // The ID of the droid
+}
+
+export type humanFragment_friends = humanFragment_friends_Human | humanFragment_friends_Droid;
 
 export interface humanFragment {
   __typename: \\"Human\\";
@@ -367,18 +379,22 @@ export interface HeroName_hero_Human_friends {
   name: string;  // The name of the character
 }
 
-export type HeroName_hero = {
+export interface HeroName_hero_Human {
   __typename: \\"Human\\";
   name: string;                                            // What this human calls themselves
   id: string;                                              // The ID of the human
   homePlanet: string | null;                               // The home planet of the human, or null if unknown
   friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
-} | {
+}
+
+export interface HeroName_hero_Droid {
   __typename: \\"Droid\\";
-  name: string;                                            // What others call this droid
-  id: string;                                              // The ID of the droid
-  appearsIn: (Episode | null)[];                           // The movies this droid appears in
-};
+  name: string;                   // What others call this droid
+  id: string;                     // The ID of the droid
+  appearsIn: (Episode | null)[];  // The movies this droid appears in
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
 
 export interface HeroName {
   hero: HeroName_hero | null;
@@ -422,24 +438,28 @@ export interface HeroName_hero_Human_friends {
   name: string;  // The name of the character
 }
 
-export interface HeroName_hero_Droid_friends {
-  __typename: \\"Human\\" | \\"Droid\\";
-  id: string;  // The ID of the character
-}
-
-export type HeroName_hero = {
+export interface HeroName_hero_Human {
   __typename: \\"Human\\";
   name: string;                                            // What this human calls themselves
   id: string;                                              // The ID of the human
   homePlanet: string | null;                               // The home planet of the human, or null if unknown
   friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
-} | {
+}
+
+export interface HeroName_hero_Droid_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  id: string;  // The ID of the character
+}
+
+export interface HeroName_hero_Droid {
   __typename: \\"Droid\\";
   name: string;                                            // What others call this droid
   id: string;                                              // The ID of the droid
   appearsIn: (Episode | null)[];                           // The movies this droid appears in
   friends: (HeroName_hero_Droid_friends | null)[] | null;  // This droid's friends, or an empty list if they have none
-};
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
 
 export interface HeroName {
   hero: HeroName_hero | null;

--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -13,29 +13,29 @@ Object {
 // ====================================================
 
 export type HeroName_hero_Human_friends = {
-  __typename: \\"Human\\",
-  name: string, // What this human calls themselves
+  __typename: \\"Human\\";
+  name: string;  // What this human calls themselves
 } | {
-  __typename: \\"Droid\\",
-  id: string,   // The ID of the droid
+  __typename: \\"Droid\\";
+  id: string;    // The ID of the droid
 };
 
 export type HeroName_hero = {
-  __typename: \\"Human\\",
-  name: string,                                            // What this human calls themselves
-  id: string,                                              // The ID of the human
-  homePlanet: string | undefined | null,                   // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | undefined | null, // This human's friends, or an empty list if they have none
+  __typename: \\"Human\\";
+  name: string;                                 // What this human calls themselves
+  id: string;                                   // The ID of the human
+  homePlanet: string | null;                    // The home planet of the human, or null if unknown
+  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
 } | {
-  __typename: \\"Droid\\",
-  name: string,                                            // What others call this droid
-  id: string,                                              // The ID of the droid
-  appearsIn: (?Episode)[],                                 // The movies this droid appears in
+  __typename: \\"Droid\\";
+  name: string;                                 // What others call this droid
+  id: string;                                   // The ID of the droid
+  appearsIn: (Episode | null)[];                // The movies this droid appears in
 };
 
-export type HeroName = {
-  hero: HeroName_hero | undefined | null
-};
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -65,10 +65,10 @@ export enum Episode {
 // GraphQL fragment: droidFragment
 // ====================================================
 
-export type droidFragment = {
-  __typename: \\"Droid\\",
-  appearsIn: (?Episode)[], // The movies this droid appears in
-};
+export interface droidFragment {
+  __typename: \\"Droid\\";
+  appearsIn: (Episode | null)[];  // The movies this droid appears in
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -99,18 +99,18 @@ export enum Episode {
 // ====================================================
 
 export type humanFragment_friends = {
-  __typename: \\"Human\\",
-  name: string, // What this human calls themselves
+  __typename: \\"Human\\";
+  name: string;  // What this human calls themselves
 } | {
-  __typename: \\"Droid\\",
-  id: string,   // The ID of the droid
+  __typename: \\"Droid\\";
+  id: string;    // The ID of the droid
 };
 
-export type humanFragment = {
-  __typename: \\"Human\\",
-  homePlanet: string | undefined | null,             // The home planet of the human, or null if unknown
-  friends: humanFragment_friends | undefined | null, // This human's friends, or an empty list if they have none
-};
+export interface humanFragment {
+  __typename: \\"Human\\";
+  homePlanet: string | null;              // The home planet of the human, or null if unknown
+  friends: humanFragment_friends | null;  // This human's friends, or an empty list if they have none
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -145,11 +145,11 @@ Object {
 // GraphQL fragment: anotherFragment
 // ====================================================
 
-export type anotherFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  id: string,   // The ID of the character
-  name: string, // The name of the character
-};
+export interface anotherFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  id: string;    // The ID of the character
+  name: string;  // The name of the character
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -172,10 +172,10 @@ export type anotherFragment = {
 // GraphQL fragment: simpleFragment
 // ====================================================
 
-export type simpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -203,18 +203,18 @@ Object {
 // GraphQL fragment: anotherFragment
 // ====================================================
 
-export type anotherFragment_Droid = {
-  __typename: \\"Droid\\",
-  id: string,   // The ID of the droid
-  name: string, // What others call this droid
-};
+export interface anotherFragment_Droid {
+  __typename: \\"Droid\\";
+  id: string;    // The ID of the droid
+  name: string;  // What others call this droid
+}
 
-export type anotherFragment_Human = {
-  __typename: \\"Human\\",
-  id: string,              // The ID of the human
-  name: string,            // What this human calls themselves
-  appearsIn: (?Episode)[], // The movies this human appears in
-};
+export interface anotherFragment_Human {
+  __typename: \\"Human\\";
+  id: string;                     // The ID of the human
+  name: string;                   // What this human calls themselves
+  appearsIn: (Episode | null)[];  // The movies this human appears in
+}
 
 export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;
 
@@ -246,10 +246,10 @@ export enum Episode {
 // GraphQL fragment: simpleFragment
 // ====================================================
 
-export type simpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -284,14 +284,14 @@ Object {
 // GraphQL query operation: CustomScalar
 // ====================================================
 
-export type CustomScalar_commentTest = {
-  __typename: \\"CommentTest\\",
-  multiLine: string | undefined | null, // This is a multi-line comment.
-};
+export interface CustomScalar_commentTest {
+  __typename: \\"CommentTest\\";
+  multiLine: string | null;  // This is a multi-line comment.
+}
 
-export type CustomScalar = {
-  commentTest: CustomScalar_commentTest | undefined | null
-};
+export interface CustomScalar {
+  commentTest: CustomScalar_commentTest | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -319,15 +319,15 @@ Object {
 // GraphQL query operation: HeroInlineFragment
 // ====================================================
 
-export type HeroInlineFragment_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
+export interface HeroInlineFragment_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
 
-export type HeroInlineFragment = {
-  hero: HeroInlineFragment_hero | undefined | null
-};
+export interface HeroInlineFragment {
+  hero: HeroInlineFragment_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -362,27 +362,27 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface HeroName_hero_Human_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
 export type HeroName_hero = {
-  __typename: \\"Human\\",
-  name: string,                                            // What this human calls themselves
-  id: string,                                              // The ID of the human
-  homePlanet: string | undefined | null,                   // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | undefined | null, // This human's friends, or an empty list if they have none
+  __typename: \\"Human\\";
+  name: string;                                 // What this human calls themselves
+  id: string;                                   // The ID of the human
+  homePlanet: string | null;                    // The home planet of the human, or null if unknown
+  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
 } | {
-  __typename: \\"Droid\\",
-  name: string,                                            // What others call this droid
-  id: string,                                              // The ID of the droid
-  appearsIn: (?Episode)[],                                 // The movies this droid appears in
+  __typename: \\"Droid\\";
+  name: string;                                 // What others call this droid
+  id: string;                                   // The ID of the droid
+  appearsIn: (Episode | null)[];                // The movies this droid appears in
 };
 
-export type HeroName = {
-  hero: HeroName_hero | undefined | null
-};
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -417,33 +417,33 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface HeroName_hero_Human_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
-export type HeroName_hero_Droid_friends = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  id: string, // The ID of the character
-};
+export interface HeroName_hero_Droid_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  id: string;  // The ID of the character
+}
 
 export type HeroName_hero = {
-  __typename: \\"Human\\",
-  name: string,                                            // What this human calls themselves
-  id: string,                                              // The ID of the human
-  homePlanet: string | undefined | null,                   // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | undefined | null, // This human's friends, or an empty list if they have none
+  __typename: \\"Human\\";
+  name: string;                                 // What this human calls themselves
+  id: string;                                   // The ID of the human
+  homePlanet: string | null;                    // The home planet of the human, or null if unknown
+  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
 } | {
-  __typename: \\"Droid\\",
-  name: string,                                            // What others call this droid
-  id: string,                                              // The ID of the droid
-  appearsIn: (?Episode)[],                                 // The movies this droid appears in
-  friends: HeroName_hero_Droid_friends | undefined | null, // This droid's friends, or an empty list if they have none
+  __typename: \\"Droid\\";
+  name: string;                                 // What others call this droid
+  id: string;                                   // The ID of the droid
+  appearsIn: (Episode | null)[];                // The movies this droid appears in
+  friends: HeroName_hero_Droid_friends | null;  // This droid's friends, or an empty list if they have none
 };
 
-export type HeroName = {
-  hero: HeroName_hero | undefined | null
-};
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -479,15 +479,15 @@ TypescriptGeneratedFile {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
+export interface HeroName_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
 
-export type HeroName = {
-  hero: HeroName_hero | undefined | null
-};
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -504,18 +504,18 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-type ReviewInput = {
-  stars: number,
-  commentary?: string | undefined | null,
-  favorite_color?: ColorInput | undefined | null,
-};
+interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
 
 // The input object sent when passing in a color
-type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
-};
+interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
 
 //==============================================================
 // END Enums and Input Objects
@@ -536,15 +536,15 @@ TypescriptGeneratedFile {
 // GraphQL query operation: SomeOther
 // ====================================================
 
-export type SomeOther_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string,            // The name of the character
-  appearsIn: (?Episode)[], // The movies this character appears in
-};
+export interface SomeOther_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;                   // The name of the character
+  appearsIn: (Episode | null)[];  // The movies this character appears in
+}
 
-export type SomeOther = {
-  hero: SomeOther_hero | undefined | null
-};
+export interface SomeOther {
+  hero: SomeOther_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -561,18 +561,18 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-type ReviewInput = {
-  stars: number,
-  commentary?: string | undefined | null,
-  favorite_color?: ColorInput | undefined | null,
-};
+interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
 
 // The input object sent when passing in a color
-type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
-};
+interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
 
 //==============================================================
 // END Enums and Input Objects
@@ -593,15 +593,15 @@ TypescriptGeneratedFile {
 // GraphQL mutation operation: ReviewMovie
 // ====================================================
 
-export type ReviewMovie_createReview = {
-  __typename: \\"Review\\",
-  stars: number,                         // The number of stars this review gave, 1-5
-  commentary: string | undefined | null, // Comment about the movie
-};
+export interface ReviewMovie_createReview {
+  __typename: \\"Review\\";
+  stars: number;              // The number of stars this review gave, 1-5
+  commentary: string | null;  // Comment about the movie
+}
 
-export type ReviewMovie = {
-  createReview: ReviewMovie_createReview | undefined | null
-};
+export interface ReviewMovie {
+  createReview: ReviewMovie_createReview | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -618,18 +618,18 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-type ReviewInput = {
-  stars: number,
-  commentary?: string | undefined | null,
-  favorite_color?: ColorInput | undefined | null,
-};
+interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
 
 // The input object sent when passing in a color
-type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
-};
+interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
 
 //==============================================================
 // END Enums and Input Objects
@@ -650,10 +650,10 @@ TypescriptGeneratedFile {
 // GraphQL fragment: someFragment
 // ====================================================
 
-export type someFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  appearsIn: (?Episode)[], // The movies this character appears in
-};
+export interface someFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  appearsIn: (Episode | null)[];  // The movies this character appears in
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -670,18 +670,18 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-type ReviewInput = {
-  stars: number,
-  commentary?: string | undefined | null,
-  favorite_color?: ColorInput | undefined | null,
-};
+interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
 
 // The input object sent when passing in a color
-type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
-};
+interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
 
 //==============================================================
 // END Enums and Input Objects
@@ -701,15 +701,15 @@ Object {
 // GraphQL query operation: HeroFragment
 // ====================================================
 
-export type HeroFragment_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
+export interface HeroFragment_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
 
-export type HeroFragment = {
-  hero: HeroFragment_hero | undefined | null
-};
+export interface HeroFragment {
+  hero: HeroFragment_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -739,10 +739,10 @@ export enum Episode {
 // GraphQL fragment: simpleFragment
 // ====================================================
 
-export type simpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -777,10 +777,10 @@ Object {
 // GraphQL fragment: SimpleFragment
 // ====================================================
 
-export type SimpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
+export interface SimpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -808,15 +808,15 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
+export interface HeroName_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
 
-export type HeroName = {
-  hero: HeroName_hero | undefined | null
-};
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -851,15 +851,15 @@ Object {
 // GraphQL mutation operation: ReviewMovie
 // ====================================================
 
-export type ReviewMovie_createReview = {
-  __typename: \\"Review\\",
-  stars: number,                         // The number of stars this review gave, 1-5
-  commentary: string | undefined | null, // Comment about the movie
-};
+export interface ReviewMovie_createReview {
+  __typename: \\"Review\\";
+  stars: number;              // The number of stars this review gave, 1-5
+  commentary: string | null;  // Comment about the movie
+}
 
-export type ReviewMovie = {
-  createReview: ReviewMovie_createReview | undefined | null
-};
+export interface ReviewMovie {
+  createReview: ReviewMovie_createReview | null;
+}
 
 //==============================================================
 // START Enums and Input Objects
@@ -876,18 +876,18 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-type ReviewInput = {
-  stars: number,
-  commentary?: string | undefined | null,
-  favorite_color?: ColorInput | undefined | null,
-};
+interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
 
 // The input object sent when passing in a color
-type ColorInput = {
-  red: number,
-  green: number,
-  blue: number,
-};
+interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
 
 //==============================================================
 // END Enums and Input Objects

--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -55,7 +55,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/droidFragment.js": TypescriptGeneratedFile {
+  "__generated__/droidFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -88,7 +88,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/humanFragment.js": TypescriptGeneratedFile {
+  "__generated__/humanFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -135,7 +135,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration fragment with fragment spreads 1`] = `
 Object {
-  "__generated__/anotherFragment.js": TypescriptGeneratedFile {
+  "__generated__/anotherFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -162,7 +162,7 @@ export interface anotherFragment {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": TypescriptGeneratedFile {
+  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -193,7 +193,7 @@ export interface simpleFragment {
 
 exports[`Typescript codeGeneration fragment with fragment spreads with inline fragment 1`] = `
 Object {
-  "__generated__/anotherFragment.js": TypescriptGeneratedFile {
+  "__generated__/anotherFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -236,7 +236,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": TypescriptGeneratedFile {
+  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -637,7 +637,7 @@ interface ColorInput {
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 7`] = `"/some/file/__generated__/someFragment.js"`;
+exports[`Typescript codeGeneration multiple files 7`] = `"/some/file/__generated__/someFragment.ts"`;
 
 exports[`Typescript codeGeneration multiple files 8`] = `
 TypescriptGeneratedFile {
@@ -729,7 +729,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": TypescriptGeneratedFile {
+  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -767,7 +767,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration simple fragment 1`] = `
 Object {
-  "__generated__/SimpleFragment.js": TypescriptGeneratedFile {
+  "__generated__/SimpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */

--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -22,15 +22,15 @@ export type HeroName_hero_Human_friends = {
 
 export type HeroName_hero = {
   __typename: \\"Human\\";
-  name: string;                                 // What this human calls themselves
-  id: string;                                   // The ID of the human
-  homePlanet: string | null;                    // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
+  name: string;                                            // What this human calls themselves
+  id: string;                                              // The ID of the human
+  homePlanet: string | null;                               // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\";
-  name: string;                                 // What others call this droid
-  id: string;                                   // The ID of the droid
-  appearsIn: (Episode | null)[];                // The movies this droid appears in
+  name: string;                                            // What others call this droid
+  id: string;                                              // The ID of the droid
+  appearsIn: (Episode | null)[];                           // The movies this droid appears in
 };
 
 export interface HeroName {
@@ -108,8 +108,8 @@ export type humanFragment_friends = {
 
 export interface humanFragment {
   __typename: \\"Human\\";
-  homePlanet: string | null;              // The home planet of the human, or null if unknown
-  friends: humanFragment_friends | null;  // This human's friends, or an empty list if they have none
+  homePlanet: string | null;                         // The home planet of the human, or null if unknown
+  friends: (humanFragment_friends | null)[] | null;  // This human's friends, or an empty list if they have none
 }
 
 //==============================================================
@@ -369,15 +369,15 @@ export interface HeroName_hero_Human_friends {
 
 export type HeroName_hero = {
   __typename: \\"Human\\";
-  name: string;                                 // What this human calls themselves
-  id: string;                                   // The ID of the human
-  homePlanet: string | null;                    // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
+  name: string;                                            // What this human calls themselves
+  id: string;                                              // The ID of the human
+  homePlanet: string | null;                               // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\";
-  name: string;                                 // What others call this droid
-  id: string;                                   // The ID of the droid
-  appearsIn: (Episode | null)[];                // The movies this droid appears in
+  name: string;                                            // What others call this droid
+  id: string;                                              // The ID of the droid
+  appearsIn: (Episode | null)[];                           // The movies this droid appears in
 };
 
 export interface HeroName {
@@ -429,16 +429,16 @@ export interface HeroName_hero_Droid_friends {
 
 export type HeroName_hero = {
   __typename: \\"Human\\";
-  name: string;                                 // What this human calls themselves
-  id: string;                                   // The ID of the human
-  homePlanet: string | null;                    // The home planet of the human, or null if unknown
-  friends: HeroName_hero_Human_friends | null;  // This human's friends, or an empty list if they have none
+  name: string;                                            // What this human calls themselves
+  id: string;                                              // The ID of the human
+  homePlanet: string | null;                               // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\";
-  name: string;                                 // What others call this droid
-  id: string;                                   // The ID of the droid
-  appearsIn: (Episode | null)[];                // The movies this droid appears in
-  friends: HeroName_hero_Droid_friends | null;  // This droid's friends, or an empty list if they have none
+  name: string;                                            // What others call this droid
+  id: string;                                              // The ID of the droid
+  appearsIn: (Episode | null)[];                           // The movies this droid appears in
+  friends: (HeroName_hero_Droid_friends | null)[] | null;  // This droid's friends, or an empty list if they have none
 };
 
 export interface HeroName {

--- a/src/javascript/typescript/__tests__/codeGeneration.ts
+++ b/src/javascript/typescript/__tests__/codeGeneration.ts
@@ -22,7 +22,7 @@ function compile(
   return compileToIR(schema, document, options);
 }
 
-describe.only('Typescript codeGeneration', () => {
+describe('Typescript codeGeneration', () => {
   test('multiple files', () => {
     const context = compile(`
       query HeroName($episode: Episode) {

--- a/src/javascript/typescript/__tests__/codeGeneration.ts
+++ b/src/javascript/typescript/__tests__/codeGeneration.ts
@@ -22,7 +22,7 @@ function compile(
   return compileToIR(schema, document, options);
 }
 
-describe('Typescript codeGeneration', () => {
+describe.only('Typescript codeGeneration', () => {
   test('multiple files', () => {
     const context = compile(`
       query HeroName($episode: Episode) {

--- a/src/javascript/typescript/__tests__/helpers.ts
+++ b/src/javascript/typescript/__tests__/helpers.ts
@@ -9,100 +9,109 @@ import {
   GraphQLScalarType,
 } from 'graphql';
 
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
-import { createTypeAnnotationFromGraphQLTypeFunction } from '../helpers';
+import { createTypeFromGraphQLTypeFunction } from '../helpers';
 
-const typeAnnotationFromGraphQLType = createTypeAnnotationFromGraphQLTypeFunction({
+const typeFromGraphQLType = createTypeFromGraphQLTypeFunction({
   passthroughCustomScalars: false
 });
 
-describe('Flow typeAnnotationFromGraphQLType', () => {
+function nullableType(type: t.TSType) {
+  return t.TSUnionType([
+    type,
+    t.TSNullKeyword()
+  ])
+}
+
+describe('Typescript typeAnnotationFromGraphQLType', () => {
   test('String', () => {
-    expect(typeAnnotationFromGraphQLType(GraphQLString))
+    expect(typeFromGraphQLType(GraphQLString))
       .toMatchObject(
-        t.nullableTypeAnnotation(
-          t.stringTypeAnnotation()
+        nullableType(
+          t.TSStringKeyword()
         )
       );
   });
 
   test('Int', () => {
-    expect(typeAnnotationFromGraphQLType(GraphQLInt))
+    expect(typeFromGraphQLType(GraphQLInt))
       .toMatchObject(
-        t.nullableTypeAnnotation(
-          t.numberTypeAnnotation()
+        nullableType(
+          t.TSNumberKeyword()
         )
       );
   });
 
   test('Float', () => {
-    expect(typeAnnotationFromGraphQLType(GraphQLFloat))
+    expect(typeFromGraphQLType(GraphQLFloat))
       .toMatchObject(
-        t.nullableTypeAnnotation(
-          t.numberTypeAnnotation()
+        nullableType(
+          t.TSNumberKeyword()
         )
       );
   });
 
   test('Boolean', () => {
-    expect(typeAnnotationFromGraphQLType(GraphQLBoolean))
+    expect(typeFromGraphQLType(GraphQLBoolean))
       .toMatchObject(
-        t.nullableTypeAnnotation(
-          t.booleanTypeAnnotation()
+        nullableType(
+          t.TSBooleanKeyword()
         )
       );
   });
 
   test('ID', () => {
-    expect(typeAnnotationFromGraphQLType(GraphQLID))
+    expect(typeFromGraphQLType(GraphQLID))
       .toMatchObject(
-        t.nullableTypeAnnotation(
-          t.stringTypeAnnotation()
+        nullableType(
+          t.TSStringKeyword()
         )
       );
   });
 
   test('String!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(GraphQLString))
-    ).toMatchObject(t.stringTypeAnnotation());
+      typeFromGraphQLType(new GraphQLNonNull(GraphQLString))
+    ).toMatchObject(t.TSStringKeyword());
   });
 
   test('Int!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(GraphQLInt))
-    ).toMatchObject(t.numberTypeAnnotation());
+      typeFromGraphQLType(new GraphQLNonNull(GraphQLInt))
+    ).toMatchObject(t.TSNumberKeyword());
   });
 
   test('Float!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(GraphQLFloat))
-    ).toMatchObject(t.numberTypeAnnotation());
+      typeFromGraphQLType(new GraphQLNonNull(GraphQLFloat))
+    ).toMatchObject(t.TSNumberKeyword());
   });
 
   test('Boolean!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(GraphQLBoolean))
-    ).toMatchObject(t.booleanTypeAnnotation());
+      typeFromGraphQLType(new GraphQLNonNull(GraphQLBoolean))
+    ).toMatchObject(t.TSBooleanKeyword());
   });
 
   test('ID!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(GraphQLID))
-    ).toMatchObject(t.stringTypeAnnotation());
+      typeFromGraphQLType(new GraphQLNonNull(GraphQLID))
+    ).toMatchObject(t.TSStringKeyword());
   });
 
   // TODO: Test GenericTypeAnnotation
 
   test('[String]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(GraphQLString))
+      typeFromGraphQLType(new GraphQLList(GraphQLString))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.stringTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSStringKeyword()
+              )
             )
           )
         )
@@ -111,12 +120,14 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Int]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(GraphQLInt))
+      typeFromGraphQLType(new GraphQLList(GraphQLInt))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.numberTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSNumberKeyword()
+              )
             )
           )
         )
@@ -125,12 +136,14 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Float]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(GraphQLFloat))
+      typeFromGraphQLType(new GraphQLList(GraphQLFloat))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.numberTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSNumberKeyword()
+              )
             )
           )
         )
@@ -139,12 +152,14 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Boolean]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(GraphQLBoolean))
+      typeFromGraphQLType(new GraphQLList(GraphQLBoolean))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.booleanTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSBooleanKeyword()
+              )
             )
           )
         )
@@ -153,12 +168,14 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[ID]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(GraphQLID))
+      typeFromGraphQLType(new GraphQLList(GraphQLID))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.stringTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSStringKeyword()
+              )
             )
           )
         )
@@ -167,11 +184,13 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[String]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLString)))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLString)))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.stringTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSStringKeyword()
+            )
           )
         )
       )
@@ -179,22 +198,26 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Int]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLInt)))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLInt)))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.numberTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSNumberKeyword()
+            )
           )
         )
       )
   });
   test('[Float]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLFloat)))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLFloat)))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.numberTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSNumberKeyword()
+            )
           )
         )
       )
@@ -202,11 +225,13 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Boolean]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLBoolean)))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLBoolean)))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.booleanTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSBooleanKeyword()
+            )
           )
         )
       )
@@ -214,11 +239,13 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[ID]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLID)))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(GraphQLID)))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.stringTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSStringKeyword()
+            )
           )
         )
       )
@@ -226,11 +253,11 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[String!]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLString)))
+      typeFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLString)))
     ).toMatchObject(
-      t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.stringTypeAnnotation()
+      nullableType(
+          t.TSArrayType(
+            t.TSStringKeyword()
           )
         )
       )
@@ -238,11 +265,11 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Int!]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLNonNull((GraphQLInt))))
+      typeFromGraphQLType(new GraphQLList(new GraphQLNonNull((GraphQLInt))))
     ).toMatchObject(
-      t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.numberTypeAnnotation()
+      nullableType(
+          t.TSArrayType(
+            t.TSNumberKeyword()
           )
         )
       )
@@ -250,11 +277,11 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Float!]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLFloat)))
+      typeFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLFloat)))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.numberTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSNumberKeyword()
           )
         )
       )
@@ -262,11 +289,11 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[Boolean!]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLBoolean)))
+      typeFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLBoolean)))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.booleanTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSBooleanKeyword()
           )
         )
       )
@@ -274,11 +301,11 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[ID!]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLID)))
+      typeFromGraphQLType(new GraphQLList(new GraphQLNonNull(GraphQLID)))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.stringTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSStringKeyword()
           )
         )
       )
@@ -286,64 +313,68 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[String!]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.stringTypeAnnotation()
+        t.TSArrayType(
+          t.TSStringKeyword()
         )
       )
   });
 
   test('[Int!]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.numberTypeAnnotation()
+        t.TSArrayType(
+          t.TSNumberKeyword()
         )
       )
   });
 
   test('[Float!]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLFloat))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLFloat))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.numberTypeAnnotation()
+        t.TSArrayType(
+          t.TSNumberKeyword()
         )
       )
   });
 
   test('[Boolean!]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLBoolean))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLBoolean))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.booleanTypeAnnotation()
+        t.TSArrayType(
+          t.TSBooleanKeyword()
         )
       )
   });
 
   test('[ID!]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLID))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLID))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.stringTypeAnnotation()
+        t.TSArrayType(
+          t.TSStringKeyword()
         )
       )
   });
 
   test('[[String]]', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLList(new GraphQLList(GraphQLString)))
+      typeFromGraphQLType(new GraphQLList(new GraphQLList(GraphQLString)))
     ).toMatchObject(
-        t.nullableTypeAnnotation(
-          t.arrayTypeAnnotation(
-            t.nullableTypeAnnotation(
-              t.arrayTypeAnnotation(
-                t.nullableTypeAnnotation(
-                  t.stringTypeAnnotation()
+        nullableType(
+          t.TSArrayType(
+            t.TSParenthesizedType(
+              nullableType(
+                t.TSArrayType(
+                  t.TSParenthesizedType(
+                    nullableType(
+                      t.TSStringKeyword()
+                    )
+                  )
                 )
               )
             )
@@ -354,13 +385,17 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
 
   test('[[String]]!', () => {
     expect(
-      typeAnnotationFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLList(GraphQLString))))
+      typeFromGraphQLType(new GraphQLNonNull(new GraphQLList(new GraphQLList(GraphQLString))))
     ).toMatchObject(
-        t.arrayTypeAnnotation(
-          t.nullableTypeAnnotation(
-            t.arrayTypeAnnotation(
-              t.nullableTypeAnnotation(
-                t.stringTypeAnnotation()
+        t.TSArrayType(
+          t.TSParenthesizedType(
+            nullableType(
+              t.TSArrayType(
+                t.TSParenthesizedType(
+                  nullableType(
+                    t.TSStringKeyword()
+                  )
+                )
               )
             )
           )
@@ -377,10 +412,10 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
     });
 
     expect(
-      typeAnnotationFromGraphQLType(OddType)
+      typeFromGraphQLType(OddType)
     ).toMatchObject(
-      t.nullableTypeAnnotation(
-        t.genericTypeAnnotation(t.identifier('Odd'))
+      nullableType(
+        t.TSTypeReference(t.identifier('Odd'))
       )
     )
   });
@@ -390,7 +425,7 @@ describe('passthrough custom scalars', () => {
   let getTypeAnnotation: Function;
 
   beforeAll(() => {
-    getTypeAnnotation = createTypeAnnotationFromGraphQLTypeFunction({
+    getTypeAnnotation = createTypeFromGraphQLTypeFunction({
       passthroughCustomScalars: true
     });
   });
@@ -406,8 +441,8 @@ describe('passthrough custom scalars', () => {
     expect(
       getTypeAnnotation(OddType)
     ).toMatchObject(
-      t.nullableTypeAnnotation(
-        t.anyTypeAnnotation()
+      nullableType(
+        t.TSAnyKeyword()
       )
     )
   });

--- a/src/javascript/typescript/codeGeneration.ts
+++ b/src/javascript/typescript/codeGeneration.ts
@@ -3,7 +3,6 @@ import { stripIndent } from 'common-tags';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLNonNull,
 } from 'graphql';
 import * as path from 'path';
 
@@ -176,7 +175,6 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
       fragmentName,
       selectionSet
     } = fragment;
-
     this.scopeStackPush(fragmentName);
 
     this.printer.enqueue(stripIndent`
@@ -249,7 +247,6 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
       variant,
       this.context.options.mergeInFieldsFromFragmentSpreads
     );
-
     return fields.map(field => {
       const fieldName = field.alias !== undefined ? field.alias : field.name;
       this.scopeStackPush(fieldName);
@@ -306,13 +303,12 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
 
     this.printer.enqueue(exportedTypeAlias);
 
-
     return {
       name: field.alias ? field.alias : field.name,
       description: field.description,
-      type: field.type instanceof GraphQLNonNull
-        ? t.TSTypeReference(generatedIdentifier)
-        : this.makeNullableType(t.TSTypeReference(generatedIdentifier))
+      type: this.typeFromGraphQLType(field.type, {
+        replaceObjectTypeIdentifierWith: generatedIdentifier
+      })
     };
   }
 

--- a/src/javascript/typescript/codeGeneration.ts
+++ b/src/javascript/typescript/codeGeneration.ts
@@ -102,7 +102,7 @@ export function generateSource(
       const outputFilePath = path.join(
         path.dirname(fragment.filePath),
         '__generated__',
-        `${fragment.fragmentName}.js`
+        `${fragment.fragmentName}.ts`
       );
 
       generatedFiles[outputFilePath] = new TypescriptGeneratedFile(output);

--- a/src/javascript/typescript/helpers.ts
+++ b/src/javascript/typescript/helpers.ts
@@ -15,64 +15,64 @@ import * as t from '@babel/types';
 import { CompilerOptions } from '../../compiler';
 
 const builtInScalarMap = {
-  [GraphQLString.name]: t.stringTypeAnnotation(),
-  [GraphQLInt.name]: t.numberTypeAnnotation(),
-  [GraphQLFloat.name]: t.numberTypeAnnotation(),
-  [GraphQLBoolean.name]: t.booleanTypeAnnotation(),
-  [GraphQLID.name]: t.stringTypeAnnotation(),
+  [GraphQLString.name]: t.TSStringKeyword(),
+  [GraphQLInt.name]: t.TSNumberKeyword(),
+  [GraphQLFloat.name]: t.TSNumberKeyword(),
+  [GraphQLBoolean.name]: t.TSBooleanKeyword(),
+  [GraphQLID.name]: t.TSStringKeyword(),
 }
 
-export function createTypeAnnotationFromGraphQLTypeFunction(
+export function createTypeFromGraphQLTypeFunction(
   compilerOptions: CompilerOptions
-): Function {
-  return function typeAnnotationFromGraphQLType(type: GraphQLType, {
+) {
+  return function typeFromGraphQLType(graphQLType: GraphQLType, {
     nullable
   } = {
     nullable: true
-  }): t.FlowTypeAnnotation {
-    if (type instanceof GraphQLNonNull) {
-      return typeAnnotationFromGraphQLType(
-        type.ofType,
+  }): t.TSType {
+    if (graphQLType instanceof GraphQLNonNull) {
+      return typeFromGraphQLType(
+        graphQLType.ofType,
         { nullable: false }
       );
     }
 
-    if (type instanceof GraphQLList) {
-      const typeAnnotation = t.arrayTypeAnnotation(
-        typeAnnotationFromGraphQLType(type.ofType)
+    if (graphQLType instanceof GraphQLList) {
+      const elementType = typeFromGraphQLType(graphQLType.ofType);
+      const type = t.TSArrayType(
+        t.isTSUnionType(elementType) ? t.TSParenthesizedType(elementType) : elementType
       );
-
       if (nullable) {
-        return t.nullableTypeAnnotation(typeAnnotation);
+        return t.TSUnionType([type, t.TSNullKeyword()]);
       } else {
-        return typeAnnotation;
+        return type;
       }
     }
 
-    let typeAnnotation;
-    if (type instanceof GraphQLScalarType) {
-      const builtIn = builtInScalarMap[type.name]
+    let type: t.TSType;
+    if (graphQLType instanceof GraphQLScalarType) {
+      const builtIn = builtInScalarMap[graphQLType.name]
       if (builtIn) {
-        typeAnnotation = builtIn;
+        type = builtIn;
       } else {
         if (compilerOptions.passthroughCustomScalars) {
-          typeAnnotation = t.anyTypeAnnotation();
+          type = t.TSAnyKeyword();
         } else {
-          typeAnnotation = t.genericTypeAnnotation(
-            t.identifier(type.name)
+          type = t.TSTypeReference(
+            t.identifier(graphQLType.name)
           );
         }
       }
     } else {
-      typeAnnotation = t.genericTypeAnnotation(
-        t.identifier(type.name)
+      type = t.TSTypeReference(
+        t.identifier(graphQLType.name)
       );
     }
 
     if (nullable) {
-      return t.nullableTypeAnnotation(typeAnnotation);
+      return t.TSUnionType([type, t.TSNullKeyword()]);
     } else {
-      return typeAnnotation;
+      return type;
     }
   }
 }

--- a/src/javascript/typescript/helpers.ts
+++ b/src/javascript/typescript/helpers.ts
@@ -22,23 +22,31 @@ const builtInScalarMap = {
   [GraphQLID.name]: t.TSStringKeyword(),
 }
 
+export interface TypeFromGraphQLTypeOptions {
+  replaceObjectTypeIdentifierWith?: t.Identifier;
+}
+
 export function createTypeFromGraphQLTypeFunction(
   compilerOptions: CompilerOptions
-) {
+): (graphQLType: GraphQLType, options?: TypeFromGraphQLTypeOptions) => t.TSType {
   return function typeFromGraphQLType(graphQLType: GraphQLType, {
-    nullable
+    nullable = true,
+    replaceObjectTypeIdentifierWith
+  }: {
+    nullable?: boolean;
+    replaceObjectTypeIdentifierWith?: t.Identifier
   } = {
     nullable: true
   }): t.TSType {
     if (graphQLType instanceof GraphQLNonNull) {
       return typeFromGraphQLType(
         graphQLType.ofType,
-        { nullable: false }
+        { nullable: false, replaceObjectTypeIdentifierWith }
       );
     }
 
     if (graphQLType instanceof GraphQLList) {
-      const elementType = typeFromGraphQLType(graphQLType.ofType);
+      const elementType = typeFromGraphQLType(graphQLType.ofType, { replaceObjectTypeIdentifierWith, nullable: true });
       const type = t.TSArrayType(
         t.isTSUnionType(elementType) ? t.TSParenthesizedType(elementType) : elementType
       );
@@ -65,7 +73,7 @@ export function createTypeFromGraphQLTypeFunction(
       }
     } else {
       type = t.TSTypeReference(
-        t.identifier(graphQLType.name)
+        replaceObjectTypeIdentifierWith ? replaceObjectTypeIdentifierWith : t.identifier(graphQLType.name)
       );
     }
 

--- a/src/javascript/typescript/language.ts
+++ b/src/javascript/typescript/language.ts
@@ -131,18 +131,6 @@ export default class TypescriptGenerator {
     );
   }
 
-  public typeAliasObjectUnion(name: string, members: ObjectProperty[][]) {
-    return t.TSTypeAliasDeclaration(
-      t.identifier(name),
-      undefined,
-      t.TSUnionType(
-        members.map(member => {
-          return t.TSTypeLiteral(this.typesForProperties(member))
-        })
-      )
-    )
-  }
-
   public typeAliasGenericUnion(name: string, members: t.TSType[]) {
     return t.TSTypeAliasDeclaration(
       t.identifier(name),
@@ -164,12 +152,11 @@ export default class TypescriptGenerator {
   public makeNullableType(type: t.TSType) {
     return t.TSUnionType([
       type,
-      // t.TSUndefinedKeyword(),
       t.TSNullKeyword()
     ])
   }
 
   public isNullableType(type: t.TSType) {
-    return t.isTSUnionType(type) && t.isTSNullKeyword(type.types[1]);
+    return t.isTSUnionType(type) && type.types.some(type => t.isTSNullKeyword(type));
   }
 }

--- a/src/javascript/typescript/language.ts
+++ b/src/javascript/typescript/language.ts
@@ -8,7 +8,7 @@ import {
   CompilerOptions
 } from '../../compiler';
 
-import { createTypeFromGraphQLTypeFunction } from './helpers';
+import { createTypeFromGraphQLTypeFunction, TypeFromGraphQLTypeOptions } from './helpers';
 
 import * as t from '@babel/types';
 
@@ -24,7 +24,7 @@ export interface TypescriptCompilerOptions extends CompilerOptions {
 
 export default class TypescriptGenerator {
   options: TypescriptCompilerOptions
-  typeFromGraphQLType: (graphQLType: GraphQLType) => t.TSType
+  typeFromGraphQLType: (graphQLType: GraphQLType, options?: TypeFromGraphQLTypeOptions) => t.TSType
 
   constructor(compilerOptions: TypescriptCompilerOptions) {
     this.options = compilerOptions;


### PR DESCRIPTION
This updates the typescript modern generator to use TS nodes from the `@babel/types` library. This fixes some invalid output in the TS generated files since we were really using flow nodes, which have slight syntax differences.