### PR TITLE
update @types/babel-types to 7.0.0 with new ts types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,13 +43,13 @@
       "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.1"
+        "@types/babel-types": "7.0.0"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.1.tgz",
-      "integrity": "sha512-7Z6r20+HE0viAFhsW0d/UrC1K2tTlpXzGpNlYm8MmCv8z5PbAacFIshrM/MjlGRa5SBqxu2socpy8FHntwZKng==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/babylon": {
@@ -58,7 +58,7 @@
       "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.1"
+        "@types/babel-types": "7.0.0"
       }
     },
     "@types/common-tags": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "npm": ">=5.0"
   },
   "devDependencies": {
+    "@babel/types": "^7.0.0-beta.35",
+    "@types/babel-generator": "^6.25.1",
+    "@types/babel-types": "^7.0.0",
+    "@types/babylon": "^6.16.2",
     "@types/common-tags": "^1.4.0",
     "@types/glob": "^5.0.34",
     "@types/graphql": "^0.11.7",
@@ -30,10 +34,8 @@
     "@types/jest": "^21.1.8",
     "@types/mkdirp": "^0.5.2",
     "@types/node-fetch": "^1.6.7",
-    "@types/yargs": "^10.0.0",
-    "@types/babel-generator": "^6.25.1",
-    "@types/babylon": "^6.16.2",
     "@types/rimraf": "^2.0.2",
+    "@types/yargs": "^10.0.0",
     "ansi-regex": "^3.0.0",
     "jest": "^22.0.3",
     "jest-matcher-utils": "^22.0.3",
@@ -42,7 +44,6 @@
   },
   "dependencies": {
     "@babel/generator": "^7.0.0-beta.35",
-    "@babel/types": "^7.0.0-beta.35",
     "change-case": "^3.0.1",
     "common-tags": "^1.5.1",
     "core-js": "^2.5.3",

--- a/src/javascript/types/augment-babel-types.ts
+++ b/src/javascript/types/augment-babel-types.ts
@@ -11,12 +11,4 @@ declare module 'babel-types' {
   interface ObjectTypeAnnotation {
     exact: boolean
   }
-
-  type TSTypeAnnotation = {
-    typeAnnotaton: TSType
-  }
-
-  type TSType = {
-    // TODO: Complete this, or wait for babel-types in DefinitelyTyped to get updated.
-  }
 }


### PR DESCRIPTION
New @types/babel-types includes type definitions for the typescript nodes.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21972

This means we don't have to hack around this anymore and we can update our TS target to use the new ts nodes throughout the TS target code generation.