### PR TITLE
Fix Flow-Modern incorrectly-flattened array generation

### DIFF
--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -22,15 +22,15 @@ export type HeroName_hero_Human_friends = {
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                               // What this human calls themselves
+  id: string,                                 // The ID of the human
+  homePlanet: ?string,                        // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friends)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
+  name: string,                               // What others call this droid
+  id: string,                                 // The ID of the droid
+  appearsIn: (?Episode)[],                    // The movies this droid appears in
 };
 
 export type HeroName = {
@@ -100,8 +100,8 @@ export type humanFragment_friends = {
 
 export type humanFragment = {
   __typename: \\"Human\\",
-  homePlanet: ?string,             // The home planet of the human, or null if unknown
-  friends: ?humanFragment_friends, // This human's friends, or an empty list if they have none
+  homePlanet: ?string,                  // The home planet of the human, or null if unknown
+  friends: ?(?humanFragment_friends)[], // This human's friends, or an empty list if they have none
 };
 
 //==============================================================
@@ -345,15 +345,15 @@ export type HeroName_hero_Human_friends = {
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                               // What this human calls themselves
+  id: string,                                 // The ID of the human
+  homePlanet: ?string,                        // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friends)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
+  name: string,                               // What others call this droid
+  id: string,                                 // The ID of the droid
+  appearsIn: (?Episode)[],                    // The movies this droid appears in
 };
 
 export type HeroName = {
@@ -401,16 +401,16 @@ export type HeroName_hero_Droid_friends = {
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                               // What this human calls themselves
+  id: string,                                 // The ID of the human
+  homePlanet: ?string,                        // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friends)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
-  friends: ?HeroName_hero_Droid_friends, // This droid's friends, or an empty list if they have none
+  name: string,                               // What others call this droid
+  id: string,                                 // The ID of the droid
+  appearsIn: (?Episode)[],                    // The movies this droid appears in
+  friends: ?(?HeroName_hero_Droid_friends)[], // This droid's friends, or an empty list if they have none
 };
 
 export type HeroName = {

--- a/src/javascript/flow/codeGeneration.ts
+++ b/src/javascript/flow/codeGeneration.ts
@@ -3,7 +3,6 @@ import { stripIndent } from 'common-tags';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLNonNull,
 } from 'graphql';
 import * as path from 'path';
 
@@ -288,9 +287,7 @@ export class FlowAPIGenerator extends FlowGenerator {
   ) {
     const { selectionSet } = field;
 
-    const selectionValueGeneratedTypeName = field.type instanceof GraphQLNonNull
-      ? generatedTypeName.id.name
-      : '?' + generatedTypeName.id.name;
+    const annotation = this.typeAnnotationFromGraphQLType(field.type, generatedTypeName.id.name);
 
     const typeCase = this.getTypeCasesForSelectionSet(selectionSet as SelectionSet);
     const variants = typeCase.exhaustiveVariants;
@@ -326,9 +323,7 @@ export class FlowAPIGenerator extends FlowGenerator {
     return {
       name: field.alias ? field.alias : field.name,
       description: field.description,
-      annotation: t.genericTypeAnnotation(
-        t.identifier(selectionValueGeneratedTypeName)
-      )
+      annotation: annotation,
     };
   }
 

--- a/src/javascript/flow/helpers.ts
+++ b/src/javascript/flow/helpers.ts
@@ -25,54 +25,35 @@ const builtInScalarMap = {
 export function createTypeAnnotationFromGraphQLTypeFunction(
   compilerOptions: CompilerOptions
 ): Function {
-  return function typeAnnotationFromGraphQLType(type: GraphQLType, {
-    nullable
-  } = {
-    nullable: true
-  }): t.FlowTypeAnnotation {
-    if (type instanceof GraphQLNonNull) {
-      return typeAnnotationFromGraphQLType(
-        type.ofType,
-        { nullable: false }
-      );
-    }
-
+  function nonNullableTypeAnnotationFromGraphQLType(type: GraphQLType, typeName?: string): t.FlowTypeAnnotation {
     if (type instanceof GraphQLList) {
-      const typeAnnotation = t.arrayTypeAnnotation(
-        typeAnnotationFromGraphQLType(type.ofType)
+      return t.arrayTypeAnnotation(
+        typeAnnotationFromGraphQLType(type.ofType, typeName)
       );
-
-      if (nullable) {
-        return t.nullableTypeAnnotation(typeAnnotation);
+    } else if (type instanceof GraphQLScalarType) {
+      const builtIn = builtInScalarMap[typeName || type.name]
+      if (builtIn != null) {
+        return builtIn;
+      } else if (compilerOptions.passthroughCustomScalars) {
+        return t.anyTypeAnnotation();
       } else {
-        return typeAnnotation;
+        return t.genericTypeAnnotation(t.identifier(typeName || type.name));
       }
-    }
-
-    let typeAnnotation;
-    if (type instanceof GraphQLScalarType) {
-      const builtIn = builtInScalarMap[type.name]
-      if (builtIn) {
-        typeAnnotation = builtIn;
-      } else {
-        if (compilerOptions.passthroughCustomScalars) {
-          typeAnnotation = t.anyTypeAnnotation();
-        } else {
-          typeAnnotation = t.genericTypeAnnotation(
-            t.identifier(type.name)
-          );
-        }
-      }
+    } else if (type instanceof GraphQLNonNull) {
+      // This won't happen; but for TypeScript completeness:
+      return typeAnnotationFromGraphQLType(type.ofType, typeName);
     } else {
-      typeAnnotation = t.genericTypeAnnotation(
-        t.identifier(type.name)
-      );
-    }
-
-    if (nullable) {
-      return t.nullableTypeAnnotation(typeAnnotation);
-    } else {
-      return typeAnnotation;
+      return t.genericTypeAnnotation(t.identifier(typeName || type.name));
     }
   }
+
+  function typeAnnotationFromGraphQLType(type: GraphQLType, typeName?: string): t.FlowTypeAnnotation {
+    if (type instanceof GraphQLNonNull) {
+      return nonNullableTypeAnnotationFromGraphQLType(type.ofType, typeName);
+    } else {
+      return t.nullableTypeAnnotation(nonNullableTypeAnnotationFromGraphQLType(type, typeName));
+    }
+  }
+
+  return typeAnnotationFromGraphQLType;
 }

--- a/src/javascript/flow/language.ts
+++ b/src/javascript/flow/language.ts
@@ -84,17 +84,14 @@ export default class FlowGenerator {
   } = {}) {
     const objectTypeAnnotation = t.objectTypeAnnotation(
       fields.map(({name, description, annotation}) => {
-
         const objectTypeProperty = t.objectTypeProperty(
-          t.identifier(
-            // Nullable fields on input objects do not have to be defined
-            // as well, so allow these fields to be "undefined"
-            (keyInheritsNullability && annotation.type === "NullableTypeAnnotation")
-              ? name + '?'
-              : name
-          ),
+          t.identifier(name),
           annotation
         );
+
+        // Nullable fields on input objects do not have to be defined
+        // as well, so allow these fields to be "undefined"
+        objectTypeProperty.optional = keyInheritsNullability && annotation.type === "NullableTypeAnnotation";
 
         if (description) {
           objectTypeProperty.trailingComments = [{

--- a/src/javascript/types/augment-babel-types.ts
+++ b/src/javascript/types/augment-babel-types.ts
@@ -9,6 +9,10 @@ declare module 'babel-types' {
   }
 
   interface ObjectTypeAnnotation {
-    exact: boolean
+    exact: boolean;
+  }
+
+  interface ObjectTypeProperty {
+    optional: boolean;
   }
 }


### PR DESCRIPTION
Fixes #325 (_Flow Modern flattens Arrays in output_)

This is an alternative implementation versus #342 which:
  * Provides full support of arbitrary nullable/nested lists without special casing top-level lists/nulls. (The `typeAnnotationFromGraphQLType` function now recursively covers all cases; the type annotations for field properties are now correctly generated from this same logic as well).
  * Does not include the inferred inflection change discussed in that PR, which is unrelated to the array-flattening issue