### PR TITLE
Added /*eslint-disable*/ comments to all flow-modern generated files

### DIFF
--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -6,6 +6,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -59,6 +60,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -88,6 +90,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -131,6 +134,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -158,6 +162,7 @@ export type anotherFragment = {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -189,6 +194,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -228,6 +234,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -262,6 +269,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -297,6 +305,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -340,6 +349,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -395,6 +405,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -457,6 +468,7 @@ FlowGeneratedFile {
   "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -514,6 +526,7 @@ FlowGeneratedFile {
   "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -571,6 +584,7 @@ FlowGeneratedFile {
   "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -629,6 +643,7 @@ FlowGeneratedFile {
   "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -676,6 +691,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -714,6 +730,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -748,6 +765,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -779,6 +797,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -822,6 +841,7 @@ Object {
     "fileContents": "
 
 /* @flow */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/javascript/flow/codeGeneration.ts
+++ b/src/javascript/flow/codeGeneration.ts
@@ -127,6 +127,7 @@ export class FlowAPIGenerator extends FlowGenerator {
     this.printer.enqueue(
       stripIndent`
         /* @flow */
+        /* eslint-disable */
         // This file was automatically generated and should not be edited.
       `
     );


### PR DESCRIPTION
The "flow-modern" target was missing the "eslint-disable" comment that was found in the "flow" target. Added it back to make the linters happy!