### PR TITLE
Support semicolons in header values

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,9 @@ yargs
         coerce: (arg) => {
           let additionalHeaders = {};
           for (const header of arg) {
-            const [name, value] = header.split(/\s*:\s*/);
+            const separator = header.indexOf(":");
+            const name = header.substring(0, separator).trim();
+            const value = header.substring(separator + 1).trim();
             if (!(name && value)) {
               throw new ToolError('Headers should be specified as "Name: Value"');
             }


### PR DESCRIPTION
Header values are currently corrupted if they contain semicolons (introspect-schema and download-schema commands). As of https://tools.ietf.org/html/rfc7230 semicolons in header values are allowed.