### PR TITLE
Log errors to stderr instead of stdout

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,7 +28,7 @@ export function logError(error: Error) {
       logErrorMessage(error.message, fileName);
     }
   } else {
-    console.log(error.stack);
+    console.error(error.stack);
   }
 }
 
@@ -37,17 +37,17 @@ export function logErrorMessage(message: string, fileName?: string, lineNumber?:
     if (fileName && lineNumber) {
       // Prefixing error output with file name, line and 'error: ',
       // so Xcode will associate it with the right file and display the error inline
-      console.log(`${fileName}:${lineNumber}: error: ${message}`);
+      console.error(`${fileName}:${lineNumber}: error: ${message}`);
     } else {
       // Prefixing error output with 'error: ', so Xcode will display it as an error
-      console.log(`error: ${message}`);
+      console.error(`error: ${message}`);
     }
   } else {
     if (fileName) {
       const truncatedFileName = '/' + fileName.split(path.sep).slice(-4).join(path.sep);
-      console.log(`...${truncatedFileName}: ${message}`);
+      console.error(`...${truncatedFileName}: ${message}`);
     } else {
-      console.log(`error: ${message}`);
+      console.error(`error: ${message}`);
     }
   }
 }


### PR DESCRIPTION
Replace all occurrences of console.log by console.error in logError functions.
This allows using apollo-codegen with other commands in a script, and separating errors from normal output.
A work-around would be to use shell redirections.

I have not written any test in the PR.