### PR TITLE
Fix "'operationId' does not exist on type '{}'" on compile

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -136,7 +136,7 @@ interface OperationIdsMap {
 
 function writeOperationIdsMap(context: any) {
   let operationIdsMap: { [id: string]: OperationIdsMap } = {};
-  Object.values(context.operations).forEach(operation => {
+  Object.keys(context.operations).map(k => context.operations[k]).forEach(operation => {
     operationIdsMap[operation.operationId] = {
       name: operation.operationName,
       source: operation.sourceWithFragments


### PR DESCRIPTION
When you run `npm run compile` it fails with error:

```
src/generate.ts(140,31): error TS2339: Property 'operationId' does not exist on type '{}'.
src/generate.ts(141,23): error TS2339: Property 'operationName' does not exist on type '{}'.
src/generate.ts(142,25): error TS2339: Property 'sourceWithFragments' does not exist on type '{}'.
```

This happens because `Object.values` is loosing types, so I've changed it to `Object.keys(o).map(k => o[k])`.