### PR TITLE
Add printSchema options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       }
     },
     "@types/graphql": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.7.tgz",
-      "integrity": "sha512-+6UMNcBeLR/G/yMIFXVA6XJhfDlPO7x6cb7ooiyN12Q6GE1l3KbupZoWBMV2Uw3F2q+i+IiaHx9rIKwLADw+7A==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.4.tgz",
+      "integrity": "sha512-zICCZ+LEeqAx/mJ2gmMChlIHiUHhsMfy050DXQ5tSR8+GS4Os0Q0vjK9KT3HVV6bXrV60t02e/3dOmnHUcibYw==",
       "dev": true
     },
     "@types/inflected": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/babylon": "^6.16.2",
     "@types/common-tags": "^1.4.0",
     "@types/glob": "^5.0.34",
-    "@types/graphql": "^0.11.7",
+    "@types/graphql": "^0.12.4",
     "@types/inflected": "^1.1.29",
     "@types/jest": "^21.1.8",
     "@types/node-fetch": "^1.6.7",

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -3,8 +3,13 @@ import * as fs from 'fs';
 import { buildClientSchema, printSchema } from 'graphql';
 
 import { ToolError } from './errors'
+import { PrinterOptions } from 'graphql/utilities/schemaPrinter';
 
-export default async function printSchemaFromIntrospectionResult(schemaPath: string, outputPath: string) {
+export default async function printSchemaFromIntrospectionResult(
+  schemaPath: string,
+  outputPath: string,
+  options?: PrinterOptions
+) {
   if (!fs.existsSync(schemaPath)) {
     throw new ToolError(`Cannot find GraphQL schema file: ${schemaPath}`);
   }
@@ -16,7 +21,7 @@ export default async function printSchemaFromIntrospectionResult(schemaPath: str
   }
 
   const schema = buildClientSchema(schemaJSON.data);
-  const schemaIDL = printSchema(schema);
+  const schemaIDL = printSchema(schema, options);
 
   if (outputPath) {
     fs.writeFileSync(outputPath, schemaIDL);


### PR DESCRIPTION
I noticed that `graphql` exposes [some options](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql/utilities/schemaPrinter.d.ts#L8) in `printSchema` function.

I need it in order for some other plugin/parser to be able to digest schema definition.

So here are two changes:

- update `@types/graphql` (these options is a recent changes)
- allow passing options to `apollo-codegen`'s `printSchema`