### PR TITLE
Update graphql version from 0.12.3 to 0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,11 +2289,11 @@
       "dev": true
     },
     "graphql": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-      "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.1.tgz",
+      "integrity": "sha512-awNp3LTrQ7dJDSX3p3PBuxNDC+WFSOrWeV6+l4Xeh2PQJVOFyQ9SZPonXRz2WZc7aIxLZsf2nDZuuuc0qyEq/A==",
       "requires": {
-        "iterall": "1.1.3"
+        "iterall": "1.2.2"
       }
     },
     "graphql-config": {
@@ -2307,6 +2307,21 @@
         "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
+          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        },
+        "iterall": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+          "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
+        }
       }
     },
     "graphql-import": {
@@ -2324,6 +2339,19 @@
           "version": "0.11.7",
           "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.7.tgz",
           "integrity": "sha512-+6UMNcBeLR/G/yMIFXVA6XJhfDlPO7x6cb7ooiyN12Q6GE1l3KbupZoWBMV2Uw3F2q+i+IiaHx9rIKwLADw+7A=="
+        },
+        "graphql": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
+          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        },
+        "iterall": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+          "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
         }
       }
     },
@@ -2836,9 +2864,9 @@
       }
     },
     "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "jest": {
       "version": "22.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "common-tags": "^1.5.1",
     "core-js": "^2.5.3",
     "glob": "^7.1.2",
-    "graphql": "^0.12.3",
+    "graphql": "^0.13.1",
     "graphql-config": "^1.1.1",
     "inflected": "^2.0.3",
     "node-fetch": "^1.7.3",

--- a/test/compiler/visitors/typeCase.ts
+++ b/test/compiler/visitors/typeCase.ts
@@ -22,12 +22,12 @@ export const animalSchema = buildSchema(`
     bodyTemperature: Int!
   }
 
-  type Cat implements Pet, WarmBlooded {
+  type Cat implements Pet & WarmBlooded {
     name: String!
     bodyTemperature: Int!
   }
 
-  type Bird implements Pet, WarmBlooded {
+  type Bird implements Pet & WarmBlooded {
     name: String!
     bodyTemperature: Int!
   }


### PR DESCRIPTION
Need to update graphql version for solving syntax changed on inherited interfaces https://github.com/graphql/graphql-js/pull/1169 

Separate multiple inherited interfaces used `,` previously but have been changed by `&`

