### PR TITLE
Fix swift codegen key when using snake-case property

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -846,18 +846,18 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         );
       });
 
-      for (const { propertyName, typeName, description } of properties) {
+      for (const { name, propertyName, typeName, description } of properties) {
         this.printNewlineIfNeeded();
         this.comment(description);
         this.printOnNewline(`public var ${escapeIdentifierIfNeeded(propertyName)}: ${typeName}`);
         this.withinBlock(() => {
           this.printOnNewline('get');
           this.withinBlock(() => {
-            this.printOnNewline(`return graphQLMap["${propertyName}"] as! ${typeName}`);
+            this.printOnNewline(`return graphQLMap["${name}"] as! ${typeName}`);
           });
           this.printOnNewline('set');
           this.withinBlock(() => {
-            this.printOnNewline(`graphQLMap.updateValue(newValue, forKey: "${propertyName}")`);
+            this.printOnNewline(`graphQLMap.updateValue(newValue, forKey: "${name}")`);
           });
         });
       }

--- a/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1533,10 +1533,10 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Favorite color, optional
   public var favoriteColor: Optional<ColorInput?> {
     get {
-      return graphQLMap[\\"favoriteColor\\"] as! Optional<ColorInput?>
+      return graphQLMap[\\"favorite_color\\"] as! Optional<ColorInput?>
     }
     set {
-      graphQLMap.updateValue(newValue, forKey: \\"favoriteColor\\")
+      graphQLMap.updateValue(newValue, forKey: \\"favorite_color\\")
     }
   }
 }"


### PR DESCRIPTION
This PR fixed the error when using snake-case in property name when generating the code for swift.
The code is using the wrong key.
