### PR TITLE
Typo on command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In case you specify multiple schemas in your `.graphqlconfig` file, choose which
 
 When using `apollo-codegen` with Typescript or Flow, make sure to add the `__typename` introspection field to every selection set within your graphql operations.
 
-If you're using a client like `apollo-client` that does this automatically for your GraphQL operations, pass in the `--addTypename` option to `apollo-codegen` to make sure the generated Typescript and Flow types have the `__typename` field as well. This is required to ensure proper type generation support for `GraphQLUnionType` and `GraphQLInterfaceType` fields.
+If you're using a client like `apollo-client` that does this automatically for your GraphQL operations, pass in the `--add-typename` option to `apollo-codegen` to make sure the generated Typescript and Flow types have the `__typename` field as well. This is required to ensure proper type generation support for `GraphQLUnionType` and `GraphQLInterfaceType` fields.
 
 ### Why is the __typename field required?
 


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

<img width="638" alt="screen shot 2018-03-20 at 11 31 03 pm" src="https://user-images.githubusercontent.com/992008/37696925-fdadad18-2c96-11e8-8f45-31c5877ce31f.png">

### Also

> If you're using a client like apollo-client that **does** this automatically for your GraphQL operations

Is **does** the correct word here, as opposed to **doesn't**?