### PR TITLE
[Swift]: Adding Namespacing to `Optional` Types

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -816,7 +816,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
     properties.forEach(property => {
       if (property.isOptional) {
-        property.typeName = `Optional<${property.typeName}>`;
+        property.typeName = `Swift.Optional<${property.typeName}>`;
       }
     });
 

--- a/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -1506,7 +1506,7 @@ exports[`Swift code generation #typeDeclarationForGraphQLType() should generate 
 public struct ReviewInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
-  public init(stars: Int, commentary: Optional<String?> = nil, favoriteColor: Optional<ColorInput?> = nil) {
+  public init(stars: Int, commentary: Swift.Optional<String?> = nil, favoriteColor: Swift.Optional<ColorInput?> = nil) {
     graphQLMap = [\\"stars\\": stars, \\"commentary\\": commentary, \\"favorite_color\\": favoriteColor]
   }
 
@@ -1521,9 +1521,9 @@ public struct ReviewInput: GraphQLMapConvertible {
   }
 
   /// Comment about the movie, optional
-  public var commentary: Optional<String?> {
+  public var commentary: Swift.Optional<String?> {
     get {
-      return graphQLMap[\\"commentary\\"] as! Optional<String?>
+      return graphQLMap[\\"commentary\\"] as! Swift.Optional<String?>
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"commentary\\")
@@ -1531,9 +1531,9 @@ public struct ReviewInput: GraphQLMapConvertible {
   }
 
   /// Favorite color, optional
-  public var favoriteColor: Optional<ColorInput?> {
+  public var favoriteColor: Swift.Optional<ColorInput?> {
     get {
-      return graphQLMap[\\"favorite_color\\"] as! Optional<ColorInput?>
+      return graphQLMap[\\"favorite_color\\"] as! Swift.Optional<ColorInput?>
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"favorite_color\\")


### PR DESCRIPTION
Added a module namespace for Swift `Optional` Types to prevent collisions and type ambiguity errors.

Details:
Ex. Realm <https://github.com/realm/Realm-cocoa>
The Realm Swift Library Internally Generates an Optional Keyword at which point Xcode fails with a type ambiguity error when the AutoGenerated files are added to the project. Adding this Namespacing locally fixes the issue, but is removed every time apollo-codegen runs.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
/label enhancement
/label swift

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->