### PR TITLE
Export input types for typescript-modern

### DIFF
--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -544,14 +544,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -605,14 +605,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -667,14 +667,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -719,14 +719,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -938,14 +938,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;

--- a/src/javascript/typescript/codeGeneration.ts
+++ b/src/javascript/typescript/codeGeneration.ts
@@ -137,7 +137,17 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
   }
 
   public typeAliasForInputObjectType(inputObjectType: GraphQLInputObjectType) {
-    this.printer.enqueue(this.inputObjectDeclaration(inputObjectType));
+    const typeAlias = this.inputObjectDeclaration(inputObjectType);
+
+    const { description } = inputObjectType;
+    const exportDeclarationOptions = description
+      ? { comments: ` ${description.replace('\n', ' ')}` }
+      : {};
+
+    delete typeAlias.leadingComments
+    const exportedTypeAlias = this.exportDeclaration(typeAlias, exportDeclarationOptions);
+    this.printer.enqueue(exportedTypeAlias);
+
   }
 
   public interfacesForOperation(operation: Operation) {

--- a/src/javascript/typescript/language.ts
+++ b/src/javascript/typescript/language.ts
@@ -142,8 +142,17 @@ export default class TypescriptGenerator {
     );
   }
 
-  public exportDeclaration(declaration: t.Declaration) {
-    return t.exportNamedDeclaration(declaration, []);
+  public exportDeclaration(declaration: t.Declaration, options: { comments?: string } = {}) {
+    const exportedDeclaration = t.exportNamedDeclaration(declaration, []);
+
+    if(options.comments) {
+      exportedDeclaration.leadingComments = [{
+        type: 'CommentLine',
+        value: options.comments,
+      } as t.CommentLine];
+    }
+
+    return exportedDeclaration;
   }
 
   public nameFromScopeStack(scope: string[]) {


### PR DESCRIPTION
This was down for flow-modern but not typescript
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
- [x] fix
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

