### PR TITLE
Generate operation functions that execute typechecked query & mutations

### DIFF
--- a/src/typescript/language.ts
+++ b/src/typescript/language.ts
@@ -46,6 +46,37 @@ export function interfaceDeclaration(generator: CodeGenerator, {
   generator.print(';');
 }
 
+export function functionDeclaration(generator: CodeGenerator, {
+  parameters,
+  operationName,
+  operationType,
+  interfaceName,
+  sourceWithFragments,
+  hasVariables,
+}: {
+    operationName: string,
+    operationType: string,
+    interfaceName: string,
+    sourceWithFragments: string,
+    parameters: (g: CodeGenerator) => void,
+    hasVariables: boolean,
+  }) {
+  generator.printNewlineIfNeeded();
+  generator.printNewline();
+  const methodName = ({ query: 'query', subscription: 'subscribe', mutation: 'mutate' } as any)[operationType];
+  const resultType = ({ query: 'ApolloQueryResult', mutation: 'FetchResult' } as any)[operationType];
+  generator.print(`export function ${operationName}(`)
+  parameters(generator);
+  generator.printNewline();
+  generator.print(`): Observable<${resultType}<${interfaceName}>> {`);
+  generator.printNewline();
+  generator.print(`  const ${operationType} = gql\`${sourceWithFragments}\`;`);
+  generator.printNewline();
+  console.log(parameters);
+  generator.print(`  return apollo.${methodName}<${interfaceName}>({ ${operationType}${hasVariables ? ", variables" : ""} });
+} `);
+}
+
 export function propertyDeclaration(generator: CodeGenerator, {
   fieldName,
   type,


### PR DESCRIPTION
This is a PoC solution to [Generated Flow/TypeScript doesn't include the actual queries](#308). It generates what I've been writing manually, which is a typed function that accepts the apollo client and the generated variables interface as parameters and returns the generated result interface.

It's a proof-of-concept because it's directly tied to `apollo-client`, and (even worse) specifically `apollo-angular`. Unsurprisingly I don't expect this PR to be accepted as-is, **the idea is to have something concrete to start talking about** in relation to #308. That said, I'd be more than happy to take suggestions to make this more worthy.

All tests pass except 16 typescript snapshot tests, because the generated code changes (obviously) and I didn't want the PR diffs to be bogged down by changes to test scripts at this point.

It generates code like this: (taken from test output)

```
import gql from 'graphql-tag';
import { Observable } from 'rxjs/Observable';
import { ApolloQueryResult } from 'apollo-client';
import { Apollo } from 'apollo-angular';
import { FetchResult } from 'apollo-link';

export function CustomScalar(
apollo: Apollo,): Observable<ApolloQueryResult<CustomScalarQuery>> {
  return apollo.query<CustomScalarQuery>({
    query: gql`query CustomScalar {
  commentTest {
    __typename
    enumCommentTest
  }
}`,
    variables: variables,
  });
}
```

```
export function ReviewMovie(
apollo: Apollo,
variables: ReviewMovieMutationVariables,): Observable<FetchResult<ReviewMovieMutation>> {
  return apollo.mutate<ReviewMovieMutation>({
    mutation: gql`mutation ReviewMovie($episode: Episode, $review: ReviewInput) {
  createReview(episode: $episode, review: $review) {
    __typename
    stars
    commentary
  }
}`,
    variables: variables,
  });
}
```

Some changes this PR needs imo:
- [ ] Remove reliance on apollo-client, apollo-angular (especially), and apollo-link. This could just be generating accepted interfaces inline like @ecstasy2 suggested, or some other idea, suggestions welcome.
- [ ] Make sure it's not possible to support this without importing `rxjs/Observable` and `graphql-tag`. I'd prefer to reduce imports.
- [x] Make it work with fragments (may be as simple as using `LegacyOperation.sourceWithFragments` instead of `.source`).
- [ ] This adds the `__typename` parameter to the source, which may cause problems. Some feedback on how this should work would be great.
- [ ] Generate prettier-formatted code.
- [ ] Add tests that actually use the generated code, and update the existing snapshot tests.
- [ ] Flow support could be a separate PR since I'm not familiar with it, but the decisions in this PR would probably help a flow implementation.... *flow* through the PR process more easily.

Feedback and suggestions welcome!

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->