### PR TITLE
Update graphql-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,11 +114,6 @@
       "integrity": "sha512-hQbL8aBM/g5S++sM1gb4yC73Dg+FK3uYE+Ioht1RPy629+LV/RmH6q+e+jbQEwKJdWAP/YE4s67CPO+ElkMivg==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.91",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
-      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g=="
-    },
     "@types/minimatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
@@ -883,12 +878,19 @@
       }
     },
     "cross-fetch": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-0.0.8.tgz",
-      "integrity": "sha1-Ae2U3EB98sAPGAf95wCnz6SKIFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.0.0.tgz",
+      "integrity": "sha512-gnx0GnDyW73iDq6DpqceL8i4GGn55PPKDzNwZkopJ3mKPcfJ0BUIXBsnYfJBVw+jFDB+hzIp2ELNRdqoxN6M3w==",
       "requires": {
-        "node-fetch": "1.7.3",
+        "node-fetch": "2.0.0",
         "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
+          "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
+        }
       }
     },
     "cross-spawn": {
@@ -2297,70 +2299,31 @@
       }
     },
     "graphql-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-1.1.1.tgz",
-      "integrity": "sha1-QPItSEXuYp0zRLMcTJ249pXdytU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
+      "integrity": "sha512-eb4FzlODifHE/Q+91QptAmkGw39wL5ToinJ2556UUsGt2drPc4tzifL+HSnHSaxiIbH8EUhc/Fa6+neinF04qA==",
       "requires": {
-        "graphql": "0.12.3",
-        "graphql-import": "0.1.8",
-        "graphql-request": "1.4.0",
+        "graphql-import": "0.4.5",
+        "graphql-request": "1.5.1",
         "js-yaml": "3.10.0",
-        "minimatch": "3.0.4",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "0.12.3",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
-          "requires": {
-            "iterall": "1.1.3"
-          }
-        },
-        "iterall": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-          "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
-        }
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4"
       }
     },
     "graphql-import": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.1.8.tgz",
-      "integrity": "sha1-QDufndg6IGqYCK4qtq+rQEDgNZ0=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
+      "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
       "requires": {
-        "@types/graphql": "0.11.7",
-        "@types/lodash": "4.14.91",
-        "graphql": "0.12.3",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "@types/graphql": {
-          "version": "0.11.7",
-          "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.7.tgz",
-          "integrity": "sha512-+6UMNcBeLR/G/yMIFXVA6XJhfDlPO7x6cb7ooiyN12Q6GE1l3KbupZoWBMV2Uw3F2q+i+IiaHx9rIKwLADw+7A=="
-        },
-        "graphql": {
-          "version": "0.12.3",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
-          "requires": {
-            "iterall": "1.1.3"
-          }
-        },
-        "iterall": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-          "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
-        }
       }
     },
     "graphql-request": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.4.0.tgz",
-      "integrity": "sha512-lAAbaq2IbeN4sGcgQgx/OtxEZ9UimpWawIEUYAw8Dk0yNAYPwWH79/ASdGrH/5aTvYHz3U7CjgoQmaiUpLJ3qw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.5.1.tgz",
+      "integrity": "sha512-p1f1q+D+5k1PMxsaZszestYW1BAEKjygliqTAhJI5nueRe74WRmwNQWAdrRBoCFRIpM0SZer98cbJF4PZHXaqg==",
       "requires": {
-        "cross-fetch": "0.0.8"
+        "cross-fetch": "2.0.0"
       }
     },
     "growly": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "core-js": "^2.5.3",
     "glob": "^7.1.2",
     "graphql": "^0.13.1",
-    "graphql-config": "^1.1.1",
+    "graphql-config": "^2.0.1",
     "inflected": "^2.0.3",
     "node-fetch": "^1.7.3",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
graphql-config@2.0.1 properly installs graphql as a peer dependency, which avoids issues with loading schemas using different GraphQL versions.

This should also fix https://github.com/apollographql/apollo-codegen/issues/406