### PR TITLE
fix inconsistent treatment of passthrough-custom-scalars

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -131,7 +131,7 @@ yargs
       },
       "passthrough-custom-scalars": {
         demand: false,
-        describe: "Don't attempt to map custom scalars [temporary option]",
+        describe: "Use the names of custom scalars as their type name [temporary option]",
         default: false
       },
       "custom-scalars-prefix": {

--- a/src/javascript/flow/__tests__/helpers.ts
+++ b/src/javascript/flow/__tests__/helpers.ts
@@ -453,7 +453,7 @@ describe('Flow typeAnnotationFromGraphQLType', () => {
       typeAnnotationFromGraphQLType(OddType)
     ).toMatchObject(
       t.nullableTypeAnnotation(
-        t.genericTypeAnnotation(t.identifier('Odd'))
+        t.anyTypeAnnotation()
       )
     )
   });
@@ -481,7 +481,36 @@ describe('passthrough custom scalars', () => {
       getTypeAnnotation(OddType)
     ).toMatchObject(
       t.nullableTypeAnnotation(
-        t.anyTypeAnnotation()
+        t.genericTypeAnnotation(t.identifier('Odd'))
+      )
+    )
+  });
+});
+
+describe('passthrough custom scalars with custom scalar prefix', () => {
+  let getTypeAnnotation: Function;
+
+  beforeAll(() => {
+    getTypeAnnotation = createTypeAnnotationFromGraphQLTypeFunction({
+      passthroughCustomScalars: true,
+      customScalarsPrefix: "Foo$",
+      useFlowReadOnlyTypes: false,
+    });
+  });
+
+  test('Custom Scalar', () => {
+    const OddType = new GraphQLScalarType({
+      name: 'Odd',
+      serialize(value) {
+        return value % 2 === 1 ? value : null
+      }
+    });
+
+    expect(
+      getTypeAnnotation(OddType)
+    ).toMatchObject(
+      t.nullableTypeAnnotation(
+        t.genericTypeAnnotation(t.identifier('Foo$Odd'))
       )
     )
   });

--- a/src/javascript/flow/helpers.ts
+++ b/src/javascript/flow/helpers.ts
@@ -42,9 +42,9 @@ export function createTypeAnnotationFromGraphQLTypeFunction(
       if (builtIn != null) {
         return builtIn;
       } else if (compilerOptions.passthroughCustomScalars) {
-        return t.anyTypeAnnotation();
+        return t.genericTypeAnnotation(t.identifier((compilerOptions.customScalarsPrefix || '') + (typeName || type.name)));
       } else {
-        return t.genericTypeAnnotation(t.identifier(typeName || type.name));
+        return t.anyTypeAnnotation();
       }
     } else if (type instanceof GraphQLNonNull) {
       // This won't happen; but for TypeScript completeness:

--- a/src/javascript/typescript/__tests__/helpers.ts
+++ b/src/javascript/typescript/__tests__/helpers.ts
@@ -415,7 +415,7 @@ describe('Typescript typeAnnotationFromGraphQLType', () => {
       typeFromGraphQLType(OddType)
     ).toMatchObject(
       nullableType(
-        t.TSTypeReference(t.identifier('Odd'))
+        t.TSAnyKeyword()
       )
     )
   });
@@ -442,8 +442,37 @@ describe('passthrough custom scalars', () => {
       getTypeAnnotation(OddType)
     ).toMatchObject(
       nullableType(
-        t.TSAnyKeyword()
+        t.TSTypeReference(t.identifier('Odd'))
       )
     )
   });
 });
+
+describe('passthrough custom scalars with custom scalar prefix', () => {
+  let getTypeAnnotation: Function;
+
+  beforeAll(() => {
+    getTypeAnnotation = createTypeFromGraphQLTypeFunction({
+      passthroughCustomScalars: true,
+      customScalarsPrefix: "Foo$",
+    });
+  });
+
+  test('Custom Scalar', () => {
+    const OddType = new GraphQLScalarType({
+      name: 'Odd',
+      serialize(value) {
+        return value % 2 === 1 ? value : null
+      }
+    });
+
+    expect(
+      getTypeAnnotation(OddType)
+    ).toMatchObject(
+      nullableType(
+        t.TSTypeReference(t.identifier('Foo$Odd'))
+      )
+    )
+  });
+});
+

--- a/src/javascript/typescript/helpers.ts
+++ b/src/javascript/typescript/helpers.ts
@@ -36,9 +36,9 @@ export function createTypeFromGraphQLTypeFunction(
       if (builtIn != null) {
         return builtIn;
       } else if (compilerOptions.passthroughCustomScalars) {
-        return t.TSAnyKeyword();
+        return t.TSTypeReference(t.identifier((compilerOptions.customScalarsPrefix || '') + graphQLType.name));
       } else {
-        return t.TSTypeReference(t.identifier(graphQLType.name));
+        return t.TSAnyKeyword();
       }
     } else if (graphQLType instanceof GraphQLNonNull) {
       // This won't happen; but for TypeScript completeness:


### PR DESCRIPTION
/label bug
/label flow
/label typescript

This fixes inconsistent treatment of the `passthrough-custom-scalars` option, and adds the ability to use `custom-scalars-prefix` on `flow-modern` and `typescript-modern`.

The `-modern` generators had the opposite behavior as the rest of the generators, although they correctly followed the guidance of the `passthrough-custom-scalars` CLI description. To minimize breakage, I changed these and the description to match the behavior of the other generators.

This fixes #418.