### PR TITLE
fix #421 - generate $Exact InputObject annotations

### DIFF
--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -628,18 +628,18 @@ export type HeroNameVariables = {
 export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 // The input object sent when someone is creating a new review
-export type ReviewInput = {
+export type ReviewInput = {|
   stars: number,
   commentary?: ?string,
   favorite_color?: ?ColorInput,
-};
+|};
 
 // The input object sent when passing in a color
-export type ColorInput = {
+export type ColorInput = {|
   red: number,
   green: number,
   blue: number,
-};
+|};
 
 //==============================================================
 // END Enums and Input Objects
@@ -686,18 +686,18 @@ export type SomeOtherVariables = {
 export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 // The input object sent when someone is creating a new review
-export type ReviewInput = {
+export type ReviewInput = {|
   stars: number,
   commentary?: ?string,
   favorite_color?: ?ColorInput,
-};
+|};
 
 // The input object sent when passing in a color
-export type ColorInput = {
+export type ColorInput = {|
   red: number,
   green: number,
   blue: number,
-};
+|};
 
 //==============================================================
 // END Enums and Input Objects
@@ -745,18 +745,18 @@ export type ReviewMovieVariables = {
 export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 // The input object sent when someone is creating a new review
-export type ReviewInput = {
+export type ReviewInput = {|
   stars: number,
   commentary?: ?string,
   favorite_color?: ?ColorInput,
-};
+|};
 
 // The input object sent when passing in a color
-export type ColorInput = {
+export type ColorInput = {|
   red: number,
   green: number,
   blue: number,
-};
+|};
 
 //==============================================================
 // END Enums and Input Objects
@@ -794,18 +794,18 @@ export type someFragment = {
 export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 // The input object sent when someone is creating a new review
-export type ReviewInput = {
+export type ReviewInput = {|
   stars: number,
   commentary?: ?string,
   favorite_color?: ?ColorInput,
-};
+|};
 
 // The input object sent when passing in a color
-export type ColorInput = {
+export type ColorInput = {|
   red: number,
   green: number,
   blue: number,
-};
+|};
 
 //==============================================================
 // END Enums and Input Objects
@@ -1002,18 +1002,18 @@ export type ReviewMovieVariables = {
 export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 // The input object sent when someone is creating a new review
-export type ReviewInput = {
+export type ReviewInput = {|
   stars: number,
   commentary?: ?string,
   favorite_color?: ?ColorInput,
-};
+|};
 
 // The input object sent when passing in a color
-export type ColorInput = {
+export type ColorInput = {|
   red: number,
   green: number,
   blue: number,
-};
+|};
 
 //==============================================================
 // END Enums and Input Objects

--- a/src/javascript/flow/language.ts
+++ b/src/javascript/flow/language.ts
@@ -76,7 +76,8 @@ export default class FlowGenerator {
       });
 
     const typeAlias = this.typeAliasObject(name, fields, {
-      keyInheritsNullability: true
+      keyInheritsNullability: true,
+      exact: true
     });
 
     return typeAlias;
@@ -120,16 +121,25 @@ export default class FlowGenerator {
   }
 
   public typeAliasObject(name: string, fields: ObjectProperty[], {
-    keyInheritsNullability = false
+    keyInheritsNullability = false,
+    exact = false
   }: {
-    keyInheritsNullability?: boolean
+    keyInheritsNullability?: boolean,
+    exact?: boolean
   } = {}) {
+
+    const objectTypeAnnotation = this.objectTypeAnnotation(fields, {
+      keyInheritsNullability
+    })
+
+    if (exact) {
+      objectTypeAnnotation.exact = true;
+    }
+
     return t.typeAlias(
       t.identifier(name),
       undefined,
-      this.objectTypeAnnotation(fields, {
-        keyInheritsNullability
-      })
+      objectTypeAnnotation
     );
   }
 


### PR DESCRIPTION
/label bug
/label flow

This fixes #421 by ensuring that all `InputObject` annotations are `$Exact` when using the `flow-modern` generator.

EDIT: I accidentally included the "typescript" label, and I don't see a way to remove it. If someone could remove that for me, it would be appreciated!