### PR TITLE
[ts-modern] export generated input types

### DIFF
--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -544,14 +544,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -605,14 +605,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -667,14 +667,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -719,14 +719,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;
@@ -938,14 +938,14 @@ export enum Episode {
 }
 
 // The input object sent when someone is creating a new review
-interface ReviewInput {
+export interface ReviewInput {
   stars: number;
   commentary?: string | null;
   favorite_color?: ColorInput | null;
 }
 
 // The input object sent when passing in a color
-interface ColorInput {
+export interface ColorInput {
   red: number;
   green: number;
   blue: number;

--- a/src/javascript/typescript/language.ts
+++ b/src/javascript/typescript/language.ts
@@ -76,9 +76,9 @@ export default class TypescriptGenerator {
         }
       });
 
-    const inputType = this.interface(name, fields, {
+    const inputType = t.exportNamedDeclaration(this.interface(name, fields, {
       keyInheritsNullability: true
-    });
+    }), []);
 
     inputType.leadingComments = [{
       type: 'CommentLine',


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] bug
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
/label bug
-->

In `ts-modern` the generated input types are not exported and thus not usable from outside the generated module. (Similiar issue in Flow was #320 ). 

This PR adds the missing 'export's to the types.

*Example **before**:*
```
//==============================================================
// START Enums and Input Objects
// All enums and input objects are included in every output file
// for now, but this will be changed soon.
// TODO: Link to issue to fix this.
//==============================================================

// ===> SearchFilter is an input type and not exported:
interface SearchFilter {
  searchString?: string | null;
  maxHits?: number | null;
}
```

*Example **after**:*
```
//==============================================================
// START Enums and Input Objects
// All enums and input objects are included in every output file
// for now, but this will be changed soon.
// TODO: Link to issue to fix this.
//==============================================================

// ===> SearchFilter is an input type and with this PR now exported:
export interface SearchFilter {
  searchString?: string | null;
  maxHits?: number | null;
}
```
