### PR TITLE
Restore ability to specify output path for modern targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ apollo-codegen generate **/*.graphql --schema schema.json --target flow --output
 apollo-codegen generate **/*.graphql --schema schema.json --target scala --output operation-result-types.scala
 ```
 
-For the `typescript-modern` and `flow-modern` targets, you can choose to output to a directory and Apollo Codegen will split up the types by the queries they are used in.
+For the `typescript` and `flow` targets, you can choose to output to a directory and Apollo Codegen will split up the types by the queries they are used in.
 
 #### `gql` template support
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ apollo-codegen generate **/*.graphql --schema schema.json --target flow --output
 apollo-codegen generate **/*.graphql --schema schema.json --target scala --output operation-result-types.scala
 ```
 
+For the `typescript-modern` and `flow-modern` targets, you can choose to output to a directory and Apollo Codegen will split up the types by the queries they are used in.
+
 #### `gql` template support
 
 If the source file for generation is a javascript or typescript file, the codegen will try to extrapolate the queries inside the [gql tag](https://github.com/apollographql/graphql-tag) templates.

--- a/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Flow codeGeneration covariant properties with $ReadOnlyArray 1`] = `
 Object {
-  "__generated__/HeroName.js": FlowGeneratedFile {
+  "HeroName.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -56,7 +56,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/droidFragment.js": FlowGeneratedFile {
+  "droidFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -86,7 +86,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/humanFragment.js": FlowGeneratedFile {
+  "humanFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -130,7 +130,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
-  "__generated__/HeroName.js": FlowGeneratedFile {
+  "HeroName.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -184,7 +184,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/droidFragment.js": FlowGeneratedFile {
+  "droidFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -214,7 +214,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/humanFragment.js": FlowGeneratedFile {
+  "humanFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -258,7 +258,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration fragment with fragment spreads 1`] = `
 Object {
-  "__generated__/anotherFragment.js": FlowGeneratedFile {
+  "anotherFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -286,7 +286,7 @@ export type anotherFragment = {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": FlowGeneratedFile {
+  "simpleFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -318,7 +318,7 @@ export type simpleFragment = {
 
 exports[`Flow codeGeneration fragment with fragment spreads with inline fragment 1`] = `
 Object {
-  "__generated__/anotherFragment.js": FlowGeneratedFile {
+  "anotherFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -358,7 +358,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": FlowGeneratedFile {
+  "simpleFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -393,7 +393,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration handles multiline graphql comments 1`] = `
 Object {
-  "__generated__/CustomScalar.js": FlowGeneratedFile {
+  "CustomScalar.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -429,7 +429,7 @@ export type CustomScalar = {
 
 exports[`Flow codeGeneration inline fragment 1`] = `
 Object {
-  "__generated__/HeroInlineFragment.js": FlowGeneratedFile {
+  "HeroInlineFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -473,7 +473,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration inline fragment on type conditions 1`] = `
 Object {
-  "__generated__/HeroName.js": FlowGeneratedFile {
+  "HeroName.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -529,7 +529,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
 Object {
-  "__generated__/HeroName.js": FlowGeneratedFile {
+  "HeroName.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -589,7 +589,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 }
 `;
 
-exports[`Flow codeGeneration multiple files 1`] = `"/some/file/__generated__/HeroName.js"`;
+exports[`Flow codeGeneration multiple files 1`] = `"HeroName.js"`;
 
 exports[`Flow codeGeneration multiple files 2`] = `
 FlowGeneratedFile {
@@ -647,7 +647,7 @@ export type ColorInput = {|
 }
 `;
 
-exports[`Flow codeGeneration multiple files 3`] = `"/some/file/__generated__/SomeOther.js"`;
+exports[`Flow codeGeneration multiple files 3`] = `"SomeOther.js"`;
 
 exports[`Flow codeGeneration multiple files 4`] = `
 FlowGeneratedFile {
@@ -705,7 +705,7 @@ export type ColorInput = {|
 }
 `;
 
-exports[`Flow codeGeneration multiple files 5`] = `"__generated__/ReviewMovie.js"`;
+exports[`Flow codeGeneration multiple files 5`] = `"ReviewMovie.js"`;
 
 exports[`Flow codeGeneration multiple files 6`] = `
 FlowGeneratedFile {
@@ -764,7 +764,7 @@ export type ColorInput = {|
 }
 `;
 
-exports[`Flow codeGeneration multiple files 7`] = `"/some/file/__generated__/someFragment.js"`;
+exports[`Flow codeGeneration multiple files 7`] = `"someFragment.js"`;
 
 exports[`Flow codeGeneration multiple files 8`] = `
 FlowGeneratedFile {
@@ -815,7 +815,7 @@ export type ColorInput = {|
 
 exports[`Flow codeGeneration query with fragment spreads 1`] = `
 Object {
-  "__generated__/HeroFragment.js": FlowGeneratedFile {
+  "HeroFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -854,7 +854,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.js": FlowGeneratedFile {
+  "simpleFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -889,7 +889,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration simple fragment 1`] = `
 Object {
-  "__generated__/SimpleFragment.js": FlowGeneratedFile {
+  "SimpleFragment.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -921,7 +921,7 @@ export type SimpleFragment = {
 
 exports[`Flow codeGeneration simple hero query 1`] = `
 Object {
-  "__generated__/HeroName.js": FlowGeneratedFile {
+  "HeroName.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */
@@ -965,7 +965,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 
 exports[`Flow codeGeneration simple mutation 1`] = `
 Object {
-  "__generated__/ReviewMovie.js": FlowGeneratedFile {
+  "ReviewMovie.js": FlowGeneratedFile {
     "fileContents": "
 
 /* @flow */

--- a/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,8 +2,25 @@
 
 exports[`Flow codeGeneration covariant properties with $ReadOnlyArray 1`] = `
 Object {
-  "HeroName.js": FlowGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroName.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -40,24 +57,10 @@ export type HeroName = {|
 
 export type HeroNameVariables = {|
   +episode?: ?Episode
-|};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "droidFragment.js": FlowGeneratedFile {
-    "fileContents": "
+|};",
+    },
+    "droidFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -70,24 +73,10 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 export type droidFragment = {|
   +__typename: \\"Droid\\",
   +appearsIn: $ReadOnlyArray<?Episode>, // The movies this droid appears in
-|};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "humanFragment.js": FlowGeneratedFile {
-    "fileContents": "
+|};",
+    },
+    "humanFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -109,13 +98,22 @@ export type humanFragment = {|
   +__typename: \\"Human\\",
   +homePlanet: ?string,                              // The home planet of the human, or null if unknown
   +friends: ?$ReadOnlyArray<?humanFragment_friends>, // This human's friends, or an empty list if they have none
-|};
+|};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration fragment spreads with inline fragments 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -124,14 +122,9 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
-  },
-}
-`;
-
-exports[`Flow codeGeneration fragment spreads with inline fragments 1`] = `
-Object {
-  "HeroName.js": FlowGeneratedFile {
-    "fileContents": "
+  "generatedFiles": Object {
+    "HeroName.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -168,24 +161,10 @@ export type HeroName = {
 
 export type HeroNameVariables = {
   episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "droidFragment.js": FlowGeneratedFile {
-    "fileContents": "
+};",
+    },
+    "droidFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -198,24 +177,10 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 export type droidFragment = {
   __typename: \\"Droid\\",
   appearsIn: Array<?Episode>, // The movies this droid appears in
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "humanFragment.js": FlowGeneratedFile {
-    "fileContents": "
+};",
+    },
+    "humanFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -237,29 +202,30 @@ export type humanFragment = {
   __typename: \\"Human\\",
   homePlanet: ?string,                     // The home planet of the human, or null if unknown
   friends: ?Array<?humanFragment_friends>, // This human's friends, or an empty list if they have none
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
+    },
   },
 }
 `;
 
 exports[`Flow codeGeneration fragment with fragment spreads 1`] = `
 Object {
-  "anotherFragment.js": FlowGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "anotherFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -273,21 +239,10 @@ export type anotherFragment = {
   __typename: \\"Human\\" | \\"Droid\\",
   id: string,   // The ID of the character
   name: string, // The name of the character
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.js": FlowGeneratedFile {
-    "fileContents": "
+};",
+    },
+    "simpleFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -300,26 +255,33 @@ export type anotherFragment = {
 export type simpleFragment = {
   __typename: \\"Human\\" | \\"Droid\\",
   name: string, // The name of the character
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
+    },
   },
 }
 `;
 
 exports[`Flow codeGeneration fragment with fragment spreads with inline fragment 1`] = `
 Object {
-  "anotherFragment.js": FlowGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "anotherFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -342,24 +304,10 @@ export type anotherFragment_Human = {
   appearsIn: Array<?Episode>, // The movies this human appears in
 };
 
-export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.js": FlowGeneratedFile {
-    "fileContents": "
+export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;",
+    },
+    "simpleFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -372,29 +320,30 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 export type simpleFragment = {
   __typename: \\"Human\\" | \\"Droid\\",
   name: string, // The name of the character
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
+    },
   },
 }
 `;
 
 exports[`Flow codeGeneration handles multiline graphql comments 1`] = `
 Object {
-  "CustomScalar.js": FlowGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "CustomScalar.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -411,26 +360,33 @@ export type CustomScalar_commentTest = {
 
 export type CustomScalar = {
   commentTest: ?CustomScalar_commentTest
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
+    },
   },
 }
 `;
 
 exports[`Flow codeGeneration inline fragment 1`] = `
 Object {
-  "HeroInlineFragment.js": FlowGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroInlineFragment.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -452,13 +408,22 @@ export type HeroInlineFragment = {
 
 export type HeroInlineFragmentVariables = {
   episode?: ?Episode
-};
+};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration inline fragment on type conditions 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -467,14 +432,9 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
-  },
-}
-`;
-
-exports[`Flow codeGeneration inline fragment on type conditions 1`] = `
-Object {
-  "HeroName.js": FlowGeneratedFile {
-    "fileContents": "
+  "generatedFiles": Object {
+    "HeroName.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -508,13 +468,22 @@ export type HeroName = {
 
 export type HeroNameVariables = {
   episode?: ?Episode
-};
+};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -523,14 +492,9 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
-  },
-}
-`;
-
-exports[`Flow codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
-Object {
-  "HeroName.js": FlowGeneratedFile {
-    "fileContents": "
+  "generatedFiles": Object {
+    "HeroName.js": FlowGeneratedFile {
+      "fileContents": "
 
 /* @flow */
 /* eslint-disable */
@@ -570,356 +534,15 @@ export type HeroName = {
 
 export type HeroNameVariables = {
   episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
+    },
   },
 }
 `;
 
-exports[`Flow codeGeneration multiple files 1`] = `"HeroName.js"`;
+exports[`Flow codeGeneration multiple files 1`] = `"generatedFiles"`;
 
 exports[`Flow codeGeneration multiple files 2`] = `
-FlowGeneratedFile {
-  "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: HeroName
-// ====================================================
-
-export type HeroName_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
-
-export type HeroName = {
-  hero: ?HeroName_hero
-};
-
-export type HeroNameVariables = {
-  episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-// The input object sent when someone is creating a new review
-export type ReviewInput = {|
-  stars: number,
-  commentary?: ?string,
-  favorite_color?: ?ColorInput,
-|};
-
-// The input object sent when passing in a color
-export type ColorInput = {|
-  red: number,
-  green: number,
-  blue: number,
-|};
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Flow codeGeneration multiple files 3`] = `"SomeOther.js"`;
-
-exports[`Flow codeGeneration multiple files 4`] = `
-FlowGeneratedFile {
-  "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: SomeOther
-// ====================================================
-
-export type SomeOther_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string,               // The name of the character
-  appearsIn: Array<?Episode>, // The movies this character appears in
-};
-
-export type SomeOther = {
-  hero: ?SomeOther_hero
-};
-
-export type SomeOtherVariables = {
-  episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-// The input object sent when someone is creating a new review
-export type ReviewInput = {|
-  stars: number,
-  commentary?: ?string,
-  favorite_color?: ?ColorInput,
-|};
-
-// The input object sent when passing in a color
-export type ColorInput = {|
-  red: number,
-  green: number,
-  blue: number,
-|};
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Flow codeGeneration multiple files 5`] = `"ReviewMovie.js"`;
-
-exports[`Flow codeGeneration multiple files 6`] = `
-FlowGeneratedFile {
-  "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL mutation operation: ReviewMovie
-// ====================================================
-
-export type ReviewMovie_createReview = {
-  __typename: \\"Review\\",
-  stars: number,       // The number of stars this review gave, 1-5
-  commentary: ?string, // Comment about the movie
-};
-
-export type ReviewMovie = {
-  createReview: ?ReviewMovie_createReview
-};
-
-export type ReviewMovieVariables = {
-  episode?: ?Episode,
-  review?: ?ReviewInput,
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-// The input object sent when someone is creating a new review
-export type ReviewInput = {|
-  stars: number,
-  commentary?: ?string,
-  favorite_color?: ?ColorInput,
-|};
-
-// The input object sent when passing in a color
-export type ColorInput = {|
-  red: number,
-  green: number,
-  blue: number,
-|};
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Flow codeGeneration multiple files 7`] = `"someFragment.js"`;
-
-exports[`Flow codeGeneration multiple files 8`] = `
-FlowGeneratedFile {
-  "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: someFragment
-// ====================================================
-
-export type someFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  appearsIn: Array<?Episode>, // The movies this character appears in
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-// The input object sent when someone is creating a new review
-export type ReviewInput = {|
-  stars: number,
-  commentary?: ?string,
-  favorite_color?: ?ColorInput,
-|};
-
-// The input object sent when passing in a color
-export type ColorInput = {|
-  red: number,
-  green: number,
-  blue: number,
-|};
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Flow codeGeneration query with fragment spreads 1`] = `
-Object {
-  "HeroFragment.js": FlowGeneratedFile {
-    "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: HeroFragment
-// ====================================================
-
-export type HeroFragment_hero = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-  id: string,   // The ID of the character
-};
-
-export type HeroFragment = {
-  hero: ?HeroFragment_hero
-};
-
-export type HeroFragmentVariables = {
-  episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.js": FlowGeneratedFile {
-    "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: simpleFragment
-// ====================================================
-
-export type simpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-}
-`;
-
-exports[`Flow codeGeneration simple fragment 1`] = `
-Object {
-  "SimpleFragment.js": FlowGeneratedFile {
-    "fileContents": "
-
-/* @flow */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: SimpleFragment
-// ====================================================
-
-export type SimpleFragment = {
-  __typename: \\"Human\\" | \\"Droid\\",
-  name: string, // The name of the character
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-}
-`;
-
-exports[`Flow codeGeneration simple hero query 1`] = `
 Object {
   "HeroName.js": FlowGeneratedFile {
     "fileContents": "
@@ -944,27 +567,8 @@ export type HeroName = {
 
 export type HeroNameVariables = {
   episode?: ?Episode
-};
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+};",
   },
-}
-`;
-
-exports[`Flow codeGeneration simple mutation 1`] = `
-Object {
   "ReviewMovie.js": FlowGeneratedFile {
     "fileContents": "
 
@@ -989,13 +593,245 @@ export type ReviewMovie = {
 export type ReviewMovieVariables = {
   episode?: ?Episode,
   review?: ?ReviewInput,
+};",
+  },
+  "SomeOther.js": FlowGeneratedFile {
+    "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SomeOther
+// ====================================================
+
+export type SomeOther_hero = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  name: string,               // The name of the character
+  appearsIn: Array<?Episode>, // The movies this character appears in
 };
+
+export type SomeOther = {
+  hero: ?SomeOther_hero
+};
+
+export type SomeOtherVariables = {
+  episode?: ?Episode
+};",
+  },
+  "someFragment.js": FlowGeneratedFile {
+    "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: someFragment
+// ====================================================
+
+export type someFragment = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  appearsIn: Array<?Episode>, // The movies this character appears in
+};",
+  },
+}
+`;
+
+exports[`Flow codeGeneration multiple files 3`] = `"common"`;
+
+exports[`Flow codeGeneration multiple files 4`] = `
+"
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+// The input object sent when someone is creating a new review
+export type ReviewInput = {|
+  stars: number,
+  commentary?: ?string,
+  favorite_color?: ?ColorInput,
+|};
+
+// The input object sent when passing in a color
+export type ColorInput = {|
+  red: number,
+  green: number,
+  blue: number,
+|};
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`Flow codeGeneration query with fragment spreads 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroFragment.js": FlowGeneratedFile {
+      "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: HeroFragment
+// ====================================================
+
+export type HeroFragment_hero = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  name: string, // The name of the character
+  id: string,   // The ID of the character
+};
+
+export type HeroFragment = {
+  hero: ?HeroFragment_hero
+};
+
+export type HeroFragmentVariables = {
+  episode?: ?Episode
+};",
+    },
+    "simpleFragment.js": FlowGeneratedFile {
+      "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: simpleFragment
+// ====================================================
+
+export type simpleFragment = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  name: string, // The name of the character
+};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration simple fragment 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "SimpleFragment.js": FlowGeneratedFile {
+      "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: SimpleFragment
+// ====================================================
+
+export type SimpleFragment = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  name: string, // The name of the character
+};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration simple hero query 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroName.js": FlowGeneratedFile {
+      "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export type HeroName_hero = {
+  __typename: \\"Human\\" | \\"Droid\\",
+  name: string, // The name of the character
+  id: string,   // The ID of the character
+};
+
+export type HeroName = {
+  hero: ?HeroName_hero
+};
+
+export type HeroNameVariables = {
+  episode?: ?Episode
+};",
+    },
+  },
+}
+`;
+
+exports[`Flow codeGeneration simple mutation 1`] = `
+Object {
+  "common": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -1018,6 +854,33 @@ export type ColorInput = {|
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
+  "generatedFiles": Object {
+    "ReviewMovie.js": FlowGeneratedFile {
+      "fileContents": "
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: ReviewMovie
+// ====================================================
+
+export type ReviewMovie_createReview = {
+  __typename: \\"Review\\",
+  stars: number,       // The number of stars this review gave, 1-5
+  commentary: ?string, // Comment about the movie
+};
+
+export type ReviewMovie = {
+  createReview: ?ReviewMovie_createReview
+};
+
+export type ReviewMovieVariables = {
+  episode?: ?Episode,
+  review?: ?ReviewInput,
+};",
+    },
   },
 }
 `;

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -4,7 +4,6 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
 } from 'graphql';
-import * as path from 'path';
 
 import {
   CompilerContext,
@@ -81,13 +80,7 @@ export function generateSource(
 
       const output = generator.printer.printAndClear();
 
-      const outputFilePath = path.join(
-        path.dirname(operation.filePath),
-        '__generated__',
-        `${operation.operationName}.js`
-      );
-
-      generatedFiles[outputFilePath] = new FlowGeneratedFile(output);
+      generatedFiles[`${operation.operationName}.js`] = new FlowGeneratedFile(output);
     });
 
   Object.values(context.fragments)
@@ -98,13 +91,7 @@ export function generateSource(
 
       const output = generator.printer.printAndClear();
 
-      const outputFilePath = path.join(
-        path.dirname(fragment.filePath),
-        '__generated__',
-        `${fragment.fragmentName}.js`
-      );
-
-      generatedFiles[outputFilePath] = new FlowGeneratedFile(output);
+      generatedFiles[`${fragment.fragmentName}.js`] = new FlowGeneratedFile(output);
     });
 
   return generatedFiles;

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -41,9 +41,6 @@ function printEnumsAndInputObjects(generator: FlowAPIGenerator, context: Compile
   generator.printer.enqueue(stripIndent`
     //==============================================================
     // START Enums and Input Objects
-    // All enums and input objects are included in every output file
-    // for now, but this will be changed soon.
-    // TODO: Link to issue to fix this.
     //==============================================================
   `);
 
@@ -76,7 +73,6 @@ export function generateSource(
     .forEach((operation) => {
       generator.fileHeader();
       generator.typeAliasesForOperation(operation);
-      printEnumsAndInputObjects(generator, context);
 
       const output = generator.printer.printAndClear();
 
@@ -87,14 +83,20 @@ export function generateSource(
     .forEach((fragment) => {
       generator.fileHeader();
       generator.typeAliasesForFragment(fragment);
-      printEnumsAndInputObjects(generator, context);
 
       const output = generator.printer.printAndClear();
 
       generatedFiles[`${fragment.fragmentName}.js`] = new FlowGeneratedFile(output);
     });
 
-  return generatedFiles;
+  generator.fileHeader();
+  printEnumsAndInputObjects(generator, context);
+  const common = generator.printer.printAndClear();
+
+  return {
+    generatedFiles,
+    common
+  };
 }
 
 export class FlowAPIGenerator extends FlowGenerator {

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,8 +2,28 @@
 
 exports[`Typescript codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
-  "HeroName.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroName.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -47,28 +67,10 @@ export interface HeroName {
 
 export interface HeroNameVariables {
   episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "droidFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+}",
+    },
+    "droidFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -80,28 +82,10 @@ export enum Episode {
 export interface droidFragment {
   __typename: \\"Droid\\";
   appearsIn: (Episode | null)[];  // The movies this droid appears in
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "humanFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+}",
+    },
+    "humanFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -126,33 +110,29 @@ export interface humanFragment {
   __typename: \\"Human\\";
   homePlanet: string | null;                         // The home planet of the human, or null if unknown
   friends: (humanFragment_friends | null)[] | null;  // This human's friends, or an empty list if they have none
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
+    },
   },
 }
 `;
 
 exports[`Typescript codeGeneration fragment with fragment spreads 1`] = `
 Object {
-  "anotherFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "anotherFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -165,21 +145,10 @@ export interface anotherFragment {
   __typename: \\"Human\\" | \\"Droid\\";
   id: string;    // The ID of the character
   name: string;  // The name of the character
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+}",
+    },
+    "simpleFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -191,26 +160,36 @@ export interface anotherFragment {
 export interface simpleFragment {
   __typename: \\"Human\\" | \\"Droid\\";
   name: string;  // The name of the character
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
+    },
   },
 }
 `;
 
 exports[`Typescript codeGeneration fragment with fragment spreads with inline fragment 1`] = `
 Object {
-  "anotherFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "anotherFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -232,28 +211,10 @@ export interface anotherFragment_Human {
   appearsIn: (Episode | null)[];  // The movies this human appears in
 }
 
-export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;",
+    },
+    "simpleFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -265,33 +226,29 @@ export enum Episode {
 export interface simpleFragment {
   __typename: \\"Human\\" | \\"Droid\\";
   name: string;  // The name of the character
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
+    },
   },
 }
 `;
 
 exports[`Typescript codeGeneration handles multiline graphql comments 1`] = `
 Object {
-  "CustomScalar.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "CustomScalar.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -307,26 +264,36 @@ export interface CustomScalar_commentTest {
 
 export interface CustomScalar {
   commentTest: CustomScalar_commentTest | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
+    },
   },
 }
 `;
 
 exports[`Typescript codeGeneration inline fragment 1`] = `
 Object {
-  "HeroInlineFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroInlineFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -347,13 +314,21 @@ export interface HeroInlineFragment {
 
 export interface HeroInlineFragmentVariables {
   episode?: Episode | null;
+}",
+    },
+  },
 }
+`;
+
+exports[`Typescript codeGeneration inline fragment on type conditions 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -366,14 +341,9 @@ export enum Episode {
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
-  },
-}
-`;
-
-exports[`Typescript codeGeneration inline fragment on type conditions 1`] = `
-Object {
-  "HeroName.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "generatedFiles": Object {
+    "HeroName.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -410,13 +380,21 @@ export interface HeroName {
 
 export interface HeroNameVariables {
   episode?: Episode | null;
+}",
+    },
+  },
 }
+`;
+
+exports[`Typescript codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -429,14 +407,9 @@ export enum Episode {
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
-  },
-}
-`;
-
-exports[`Typescript codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
-Object {
-  "HeroName.ts": TypescriptGeneratedFile {
-    "fileContents": "
+  "generatedFiles": Object {
+    "HeroName.ts": TypescriptGeneratedFile {
+      "fileContents": "
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -479,335 +452,15 @@ export interface HeroName {
 
 export interface HeroNameVariables {
   episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
+    },
   },
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 1`] = `"HeroName.ts"`;
+exports[`Typescript codeGeneration multiple files 1`] = `"generatedFiles"`;
 
 exports[`Typescript codeGeneration multiple files 2`] = `
-TypescriptGeneratedFile {
-  "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: HeroName
-// ====================================================
-
-export interface HeroName_hero {
-  __typename: \\"Human\\" | \\"Droid\\";
-  name: string;  // The name of the character
-  id: string;    // The ID of the character
-}
-
-export interface HeroName {
-  hero: HeroName_hero | null;
-}
-
-export interface HeroNameVariables {
-  episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Typescript codeGeneration multiple files 3`] = `"SomeOther.ts"`;
-
-exports[`Typescript codeGeneration multiple files 4`] = `
-TypescriptGeneratedFile {
-  "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: SomeOther
-// ====================================================
-
-export interface SomeOther_hero {
-  __typename: \\"Human\\" | \\"Droid\\";
-  name: string;                   // The name of the character
-  appearsIn: (Episode | null)[];  // The movies this character appears in
-}
-
-export interface SomeOther {
-  hero: SomeOther_hero | null;
-}
-
-export interface SomeOtherVariables {
-  episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Typescript codeGeneration multiple files 5`] = `"ReviewMovie.ts"`;
-
-exports[`Typescript codeGeneration multiple files 6`] = `
-TypescriptGeneratedFile {
-  "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL mutation operation: ReviewMovie
-// ====================================================
-
-export interface ReviewMovie_createReview {
-  __typename: \\"Review\\";
-  stars: number;              // The number of stars this review gave, 1-5
-  commentary: string | null;  // Comment about the movie
-}
-
-export interface ReviewMovie {
-  createReview: ReviewMovie_createReview | null;
-}
-
-export interface ReviewMovieVariables {
-  episode?: Episode | null;
-  review?: ReviewInput | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-// The input object sent when someone is creating a new review
-export interface ReviewInput {
-  stars: number;
-  commentary?: string | null;
-  favorite_color?: ColorInput | null;
-}
-
-// The input object sent when passing in a color
-export interface ColorInput {
-  red: number;
-  green: number;
-  blue: number;
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Typescript codeGeneration multiple files 7`] = `"someFragment.ts"`;
-
-exports[`Typescript codeGeneration multiple files 8`] = `
-TypescriptGeneratedFile {
-  "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: someFragment
-// ====================================================
-
-export interface someFragment {
-  __typename: \\"Human\\" | \\"Droid\\";
-  appearsIn: (Episode | null)[];  // The movies this character appears in
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-}
-`;
-
-exports[`Typescript codeGeneration query with fragment spreads 1`] = `
-Object {
-  "HeroFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: HeroFragment
-// ====================================================
-
-export interface HeroFragment_hero {
-  __typename: \\"Human\\" | \\"Droid\\";
-  name: string;  // The name of the character
-  id: string;    // The ID of the character
-}
-
-export interface HeroFragment {
-  hero: HeroFragment_hero | null;
-}
-
-export interface HeroFragmentVariables {
-  episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-  "simpleFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: simpleFragment
-// ====================================================
-
-export interface simpleFragment {
-  __typename: \\"Human\\" | \\"Droid\\";
-  name: string;  // The name of the character
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-}
-`;
-
-exports[`Typescript codeGeneration simple fragment 1`] = `
-Object {
-  "SimpleFragment.ts": TypescriptGeneratedFile {
-    "fileContents": "
-
-/* tslint:disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: SimpleFragment
-// ====================================================
-
-export interface SimpleFragment {
-  __typename: \\"Human\\" | \\"Droid\\";
-  name: string;  // The name of the character
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
-  },
-}
-`;
-
-exports[`Typescript codeGeneration simple hero query 1`] = `
 Object {
   "HeroName.ts": TypescriptGeneratedFile {
     "fileContents": "
@@ -831,31 +484,8 @@ export interface HeroName {
 
 export interface HeroNameVariables {
   episode?: Episode | null;
-}
-
-//==============================================================
-// START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
-//==============================================================
-
-// The episodes in the Star Wars trilogy
-export enum Episode {
-  EMPIRE = \\"EMPIRE\\",
-  JEDI = \\"JEDI\\",
-  NEWHOPE = \\"NEWHOPE\\",
-}
-
-//==============================================================
-// END Enums and Input Objects
-//==============================================================",
+}",
   },
-}
-`;
-
-exports[`Typescript codeGeneration simple mutation 1`] = `
-Object {
   "ReviewMovie.ts": TypescriptGeneratedFile {
     "fileContents": "
 
@@ -879,13 +509,246 @@ export interface ReviewMovie {
 export interface ReviewMovieVariables {
   episode?: Episode | null;
   review?: ReviewInput | null;
+}",
+  },
+  "SomeOther.ts": TypescriptGeneratedFile {
+    "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SomeOther
+// ====================================================
+
+export interface SomeOther_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;                   // The name of the character
+  appearsIn: (Episode | null)[];  // The movies this character appears in
 }
+
+export interface SomeOther {
+  hero: SomeOther_hero | null;
+}
+
+export interface SomeOtherVariables {
+  episode?: Episode | null;
+}",
+  },
+  "someFragment.ts": TypescriptGeneratedFile {
+    "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: someFragment
+// ====================================================
+
+export interface someFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  appearsIn: (Episode | null)[];  // The movies this character appears in
+}",
+  },
+}
+`;
+
+exports[`Typescript codeGeneration multiple files 3`] = `"common"`;
+
+exports[`Typescript codeGeneration multiple files 4`] = `
+"
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
 
 //==============================================================
 // START Enums and Input Objects
-// All enums and input objects are included in every output file
-// for now, but this will be changed soon.
-// TODO: Link to issue to fix this.
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+// The input object sent when someone is creating a new review
+export interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
+
+// The input object sent when passing in a color
+export interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`Typescript codeGeneration query with fragment spreads 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: HeroFragment
+// ====================================================
+
+export interface HeroFragment_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
+
+export interface HeroFragment {
+  hero: HeroFragment_hero | null;
+}
+
+export interface HeroFragmentVariables {
+  episode?: Episode | null;
+}",
+    },
+    "simpleFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: simpleFragment
+// ====================================================
+
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}",
+    },
+  },
+}
+`;
+
+exports[`Typescript codeGeneration simple fragment 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "SimpleFragment.ts": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: SimpleFragment
+// ====================================================
+
+export interface SimpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+}",
+    },
+  },
+}
+`;
+
+exports[`Typescript codeGeneration simple hero query 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+// The episodes in the Star Wars trilogy
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+  "generatedFiles": Object {
+    "HeroName.ts": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  name: string;  // The name of the character
+  id: string;    // The ID of the character
+}
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}",
+    },
+  },
+}
+`;
+
+exports[`Typescript codeGeneration simple mutation 1`] = `
+Object {
+  "common": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
 //==============================================================
 
 // The episodes in the Star Wars trilogy
@@ -912,6 +775,32 @@ export interface ColorInput {
 //==============================================================
 // END Enums and Input Objects
 //==============================================================",
+  "generatedFiles": Object {
+    "ReviewMovie.ts": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: ReviewMovie
+// ====================================================
+
+export interface ReviewMovie_createReview {
+  __typename: \\"Review\\";
+  stars: number;              // The number of stars this review gave, 1-5
+  commentary: string | null;  // Comment about the movie
+}
+
+export interface ReviewMovie {
+  createReview: ReviewMovie_createReview | null;
+}
+
+export interface ReviewMovieVariables {
+  episode?: Episode | null;
+  review?: ReviewInput | null;
+}",
+    },
   },
 }
 `;

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Typescript codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
-  "__generated__/HeroName.ts": TypescriptGeneratedFile {
+  "HeroName.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -67,7 +67,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/droidFragment.ts": TypescriptGeneratedFile {
+  "droidFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -100,7 +100,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/humanFragment.ts": TypescriptGeneratedFile {
+  "humanFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -151,7 +151,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration fragment with fragment spreads 1`] = `
 Object {
-  "__generated__/anotherFragment.ts": TypescriptGeneratedFile {
+  "anotherFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -178,7 +178,7 @@ export interface anotherFragment {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
+  "simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -209,7 +209,7 @@ export interface simpleFragment {
 
 exports[`Typescript codeGeneration fragment with fragment spreads with inline fragment 1`] = `
 Object {
-  "__generated__/anotherFragment.ts": TypescriptGeneratedFile {
+  "anotherFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -252,7 +252,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
+  "simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -290,7 +290,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration handles multiline graphql comments 1`] = `
 Object {
-  "__generated__/CustomScalar.ts": TypescriptGeneratedFile {
+  "CustomScalar.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -325,7 +325,7 @@ export interface CustomScalar {
 
 exports[`Typescript codeGeneration inline fragment 1`] = `
 Object {
-  "__generated__/HeroInlineFragment.ts": TypescriptGeneratedFile {
+  "HeroInlineFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -372,7 +372,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration inline fragment on type conditions 1`] = `
 Object {
-  "__generated__/HeroName.ts": TypescriptGeneratedFile {
+  "HeroName.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -435,7 +435,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration inline fragment on type conditions with differing inner fields 1`] = `
 Object {
-  "__generated__/HeroName.ts": TypescriptGeneratedFile {
+  "HeroName.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -502,7 +502,7 @@ export enum Episode {
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 1`] = `"/some/file/__generated__/HeroName.ts"`;
+exports[`Typescript codeGeneration multiple files 1`] = `"HeroName.ts"`;
 
 exports[`Typescript codeGeneration multiple files 2`] = `
 TypescriptGeneratedFile {
@@ -549,7 +549,7 @@ export enum Episode {
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 3`] = `"/some/file/__generated__/SomeOther.ts"`;
+exports[`Typescript codeGeneration multiple files 3`] = `"SomeOther.ts"`;
 
 exports[`Typescript codeGeneration multiple files 4`] = `
 TypescriptGeneratedFile {
@@ -596,7 +596,7 @@ export enum Episode {
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 5`] = `"__generated__/ReviewMovie.ts"`;
+exports[`Typescript codeGeneration multiple files 5`] = `"ReviewMovie.ts"`;
 
 exports[`Typescript codeGeneration multiple files 6`] = `
 TypescriptGeneratedFile {
@@ -658,7 +658,7 @@ export interface ColorInput {
 }
 `;
 
-exports[`Typescript codeGeneration multiple files 7`] = `"/some/file/__generated__/someFragment.ts"`;
+exports[`Typescript codeGeneration multiple files 7`] = `"someFragment.ts"`;
 
 exports[`Typescript codeGeneration multiple files 8`] = `
 TypescriptGeneratedFile {
@@ -698,7 +698,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration query with fragment spreads 1`] = `
 Object {
-  "__generated__/HeroFragment.ts": TypescriptGeneratedFile {
+  "HeroFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -740,7 +740,7 @@ export enum Episode {
 // END Enums and Input Objects
 //==============================================================",
   },
-  "__generated__/simpleFragment.ts": TypescriptGeneratedFile {
+  "simpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -778,7 +778,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration simple fragment 1`] = `
 Object {
-  "__generated__/SimpleFragment.ts": TypescriptGeneratedFile {
+  "SimpleFragment.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -809,7 +809,7 @@ export interface SimpleFragment {
 
 exports[`Typescript codeGeneration simple hero query 1`] = `
 Object {
-  "__generated__/HeroName.ts": TypescriptGeneratedFile {
+  "HeroName.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */
@@ -856,7 +856,7 @@ export enum Episode {
 
 exports[`Typescript codeGeneration simple mutation 1`] = `
 Object {
-  "__generated__/ReviewMovie.ts": TypescriptGeneratedFile {
+  "ReviewMovie.ts": TypescriptGeneratedFile {
     "fileContents": "
 
 /* tslint:disable */

--- a/packages/apollo-codegen-typescript/src/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/codeGeneration.ts
@@ -45,9 +45,6 @@ function printEnumsAndInputObjects(generator: TypescriptAPIGenerator, typesUsed:
   generator.printer.enqueue(stripIndent`
     //==============================================================
     // START Enums and Input Objects
-    // All enums and input objects are included in every output file
-    // for now, but this will be changed soon.
-    // TODO: Link to issue to fix this.
     //==============================================================
   `);
 
@@ -81,9 +78,6 @@ export function generateSource(
       generator.fileHeader();
       generator.interfacesForOperation(operation);
 
-      const typesUsed = generator.getTypesUsedForOperation(operation, context);
-      printEnumsAndInputObjects(generator, typesUsed);
-
       const output = generator.printer.printAndClear();
 
       generatedFiles[`${operation.operationName}.ts`] = new TypescriptGeneratedFile(output);
@@ -94,15 +88,19 @@ export function generateSource(
       generator.fileHeader();
       generator.interfacesForFragment(fragment);
 
-      const typesUsed = generator.getTypesUsedForOperation(fragment, context);
-      printEnumsAndInputObjects(generator, typesUsed);
-
       const output = generator.printer.printAndClear();
 
       generatedFiles[`${fragment.fragmentName}.ts`] = new TypescriptGeneratedFile(output);
     });
 
-  return generatedFiles;
+  generator.fileHeader();
+  printEnumsAndInputObjects(generator, context.typesUsed);
+  const common = generator.printer.printAndClear();
+
+  return {
+    generatedFiles,
+    common
+  };
 }
 
 export class TypescriptAPIGenerator extends TypescriptGenerator {

--- a/packages/apollo-codegen-typescript/src/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/codeGeneration.ts
@@ -4,7 +4,6 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
 } from 'graphql';
-import * as path from 'path';
 
 import {
   CompilerContext,
@@ -87,13 +86,7 @@ export function generateSource(
 
       const output = generator.printer.printAndClear();
 
-      const outputFilePath = path.join(
-        path.dirname(operation.filePath),
-        '__generated__',
-        `${operation.operationName}.ts`
-      );
-
-      generatedFiles[outputFilePath] = new TypescriptGeneratedFile(output);
+      generatedFiles[`${operation.operationName}.ts`] = new TypescriptGeneratedFile(output);
     });
 
   Object.values(context.fragments)
@@ -106,13 +99,7 @@ export function generateSource(
 
       const output = generator.printer.printAndClear();
 
-      const outputFilePath = path.join(
-        path.dirname(fragment.filePath),
-        '__generated__',
-        `${fragment.fragmentName}.ts`
-      );
-
-      generatedFiles[outputFilePath] = new TypescriptGeneratedFile(output);
+      generatedFiles[`${fragment.fragmentName}.ts`] = new TypescriptGeneratedFile(output);
     });
 
   return generatedFiles;

--- a/packages/apollo-codegen/src/cli.js
+++ b/packages/apollo-codegen/src/cli.js
@@ -5,10 +5,12 @@ import * as process from 'process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 
-import { downloadSchema, introspectSchema, printSchema, generate } from 'apollo-codegen-core';
-import { ToolError, logError } from 'apollo-codegen-core/lib/errors'
+import { downloadSchema, introspectSchema, printSchema } from 'apollo-codegen-core';
+import { ToolError, logError } from 'apollo-codegen-core/lib/errors';
 
-import 'source-map-support/register'
+import generate from './generate';
+
+import 'source-map-support/register';
 
 // Make sure unhandled errors in async code are propagated correctly
 process.on('unhandledRejection', (error) => { throw error });

--- a/packages/apollo-codegen/src/cli.ts
+++ b/packages/apollo-codegen/src/cli.ts
@@ -123,7 +123,7 @@ yargs
       target: {
         demand: false,
         describe: 'Code generation target language',
-        choices: ['swift', 'scala', 'json', 'ts', 'ts-modern', 'typescript', 'typescript-modern', 'flow', 'flow-modern'],
+        choices: ['swift', 'scala', 'json', 'ts-legacy', 'ts', 'typescript-legacy', 'typescript', 'flow-leagcy', 'flow'],
         default: 'swift'
       },
       only: {
@@ -154,13 +154,13 @@ yargs
       },
       "use-flow-exact-objects": {
         demand: false,
-        describe: "Use Flow exact objects for generated types [flow-modern only]",
+        describe: "Use Flow exact objects for generated types [flow only]",
         default: false,
         type: 'boolean'
       },
       "use-flow-read-only-types": {
         demand: false,
-        describe: "Use Flow read only types for generated types [flow-modern only]",
+        describe: "Use Flow read only types for generated types [flow only]",
         default: false,
         type: 'boolean'
       },

--- a/packages/apollo-codegen/src/cli.ts
+++ b/packages/apollo-codegen/src/cli.ts
@@ -115,6 +115,7 @@ yargs
         coerce: path.resolve,
       },
       output: {
+        demand: true,
         describe: 'Output directory for the generated files',
         normalize: true,
         coerce: path.resolve,

--- a/packages/apollo-codegen/src/cli.ts
+++ b/packages/apollo-codegen/src/cli.ts
@@ -5,7 +5,9 @@ import * as process from 'process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 
-import { downloadSchema, introspectSchema, printSchema } from 'apollo-codegen-core';
+import downloadSchema from './downloadSchema';
+import introspectSchema from './introspectSchema';
+import printSchema from './printSchema';
 import { ToolError, logError } from 'apollo-codegen-core/lib/errors';
 
 import generate from './generate';
@@ -17,7 +19,7 @@ process.on('unhandledRejection', (error) => { throw error });
 
 process.on('uncaughtException', handleError);
 
-function handleError(error) {
+function handleError(error: Error) {
   logError(error);
   process.exit(1);
 }
@@ -39,7 +41,9 @@ yargs
         describe: 'Additional header to send to the server as part of the introspection query request',
         type: 'array',
         coerce: (arg) => {
-          let additionalHeaders = {};
+          let additionalHeaders: {
+            [key: string]: any
+          } = {};
           for (const header of arg) {
             const separator = header.indexOf(":");
             const name = header.substring(0, separator).trim();
@@ -189,7 +193,7 @@ yargs
         input = glob.sync(input[0]);
       }
 
-      const inputPaths = input
+      const inputPaths = (input as string[])
         .map(input => path.resolve(input))
         // Sort to normalize different glob expansions between different terminals.
         .sort();

--- a/packages/apollo-codegen/src/generate.ts
+++ b/packages/apollo-codegen/src/generate.ts
@@ -58,7 +58,7 @@ export default function generate(
   }
   else if (target === 'flow-modern' || target === 'typescript-modern' || target === 'ts-modern') {
     const context = compileToIR(schema, document, options);
-    const generatedFiles = target === 'flow-modern'
+    const { generatedFiles, common } = target === 'flow-modern'
       ? generateFlowModernSource(context)
       : generateTypescriptModernSource(context) ;
 
@@ -71,8 +71,10 @@ export default function generate(
     if (outputIndividualFiles) {
       Object.keys(generatedFiles)
         .forEach((filePath: string) => {
-          outFiles[path.basename(filePath)] = generatedFiles[filePath];
-        })
+          outFiles[path.basename(filePath)] = {
+            output: generatedFiles[filePath].fileContents + common
+          }
+        });
 
       writeGeneratedFiles(
         outFiles,
@@ -81,7 +83,7 @@ export default function generate(
     } else {
       fs.writeFileSync(
         outputPath,
-        Object.values(generatedFiles).map(v => v.fileContents).join("\n")
+        Object.values(generatedFiles).map(v => v.fileContents).join("\n") + common
       );
     }
   }

--- a/packages/apollo-codegen/src/generate.ts
+++ b/packages/apollo-codegen/src/generate.ts
@@ -62,32 +62,28 @@ export default function generate(
       ? generateFlowModernSource(context)
       : generateTypescriptModernSource(context) ;
 
-    // Group by output directory
-    const filesByOutputDirectory: {
-      [outputDirectory: string]: {
-        [fileName: string]: BasicGeneratedFile
-      }
+    const outFiles: {
+      [fileName: string]: BasicGeneratedFile
     } = {};
 
-    Object.keys(generatedFiles)
-      .forEach((filePath: string) => {
-        const outputDirectory = path.dirname(filePath);
-        if (!filesByOutputDirectory[outputDirectory]) {
-          filesByOutputDirectory[outputDirectory] = {
-            [path.basename(filePath)]: generatedFiles[filePath]
-          };
-        } else {
-          filesByOutputDirectory[outputDirectory][path.basename(filePath)] = generatedFiles[filePath];
-        }
-      })
+    const outputIndividualFiles = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
-    Object.keys(filesByOutputDirectory)
-      .forEach((outputDirectory) => {
-        writeGeneratedFiles(
-          filesByOutputDirectory[outputDirectory],
-          outputDirectory
-        );
-      });
+    if (outputIndividualFiles) {
+      Object.keys(generatedFiles)
+        .forEach((filePath: string) => {
+          outFiles[path.basename(filePath)] = generatedFiles[filePath];
+        })
+
+      writeGeneratedFiles(
+        outFiles,
+        outputPath
+      );
+    } else {
+      fs.writeFileSync(
+        outputPath,
+        Object.values(generatedFiles).map(v => v.fileContents).join("\n")
+      );
+    }
   }
   else {
     let output;

--- a/packages/apollo-codegen/src/generate.ts
+++ b/packages/apollo-codegen/src/generate.ts
@@ -10,15 +10,15 @@ import serializeToJSON from 'apollo-codegen-core/lib/serializeToJSON';
 import { BasicGeneratedFile } from 'apollo-codegen-core/lib/utilities/CodeGenerator'
 
 import { generateSource as generateSwiftSource } from 'apollo-codegen-swift';
-import { generateSource as generateTypescriptSource } from 'apollo-codegen-typescript-legacy';
-import { generateSource as generateFlowSource } from 'apollo-codegen-flow-legacy';
-import { generateSource as generateFlowModernSource } from 'apollo-codegen-flow';
-import { generateSource as generateTypescriptModernSource } from 'apollo-codegen-typescript';
+import { generateSource as generateTypescriptLegacySource } from 'apollo-codegen-typescript-legacy';
+import { generateSource as generateFlowLegacySource } from 'apollo-codegen-flow-legacy';
+import { generateSource as generateFlowSource } from 'apollo-codegen-flow';
+import { generateSource as generateTypescriptSource } from 'apollo-codegen-typescript';
 import { generateSource as generateScalaSource } from 'apollo-codegen-scala';
 
-type TargetType = 'json' | 'swift' | 'ts' | 'typescript'
-  | 'flow' | 'scala' | 'flow-modern' | 'typescript-modern'
-  | 'ts-modern';
+type TargetType = 'json' | 'swift' | 'ts-legacy' | 'typescript-legacy'
+  | 'flow-legacy' | 'scala' | 'flow' | 'typescript'
+  | 'ts';
 
 export default function generate(
   inputPaths: string[],
@@ -56,11 +56,11 @@ export default function generate(
       writeOperationIdsMap(context);
     }
   }
-  else if (target === 'flow-modern' || target === 'typescript-modern' || target === 'ts-modern') {
+  else if (target === 'flow' || target === 'typescript' || target === 'ts') {
     const context = compileToIR(schema, document, options);
-    const { generatedFiles, common } = target === 'flow-modern'
-      ? generateFlowModernSource(context)
-      : generateTypescriptModernSource(context) ;
+    const { generatedFiles, common } = target === 'flow'
+      ? generateFlowSource(context)
+      : generateTypescriptSource(context) ;
 
     const outFiles: {
       [fileName: string]: BasicGeneratedFile
@@ -94,12 +94,12 @@ export default function generate(
       case 'json':
         output = serializeToJSON(context);
         break;
-      case 'ts':
-      case 'typescript':
-        output = generateTypescriptSource(context);
+      case 'ts-legacy':
+      case 'typescript-legacy':
+        output = generateTypescriptLegacySource(context);
         break;
-      case 'flow':
-        output = generateFlowSource(context);
+      case 'flow-legacy':
+        output = generateFlowLegacySource(context);
         break;
       case 'scala':
         output = generateScalaSource(context);


### PR DESCRIPTION
Previously, modern targets outputted types right next to the GraphQL queries, which didn't handle many use cases. This makes it possible to specify an output file or directory and have the CLI write the types there.

One special change to handle outputting to both a single and multiple files is the introduction of a `common` body of code, which is included in every file but not duplicated when merging everything into one file.