### PR TITLE
[cli, flow-legacy] Fix CLI typo for flow-legacy

### DIFF
--- a/packages/apollo-codegen/src/cli.ts
+++ b/packages/apollo-codegen/src/cli.ts
@@ -125,7 +125,7 @@ yargs
       target: {
         demand: false,
         describe: 'Code generation target language',
-        choices: ['swift', 'scala', 'json', 'ts-legacy', 'ts', 'typescript-legacy', 'typescript', 'flow-leagcy', 'flow'],
+        choices: ['swift', 'scala', 'json', 'ts-legacy', 'ts', 'typescript-legacy', 'typescript', 'flow-legacy', 'flow'],
         default: 'swift'
       },
       only: {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This typo breaks backwards compatibility with `flow` users from `0.19.0` because we can no longer use `flow-legacy` since you can't provide the right CLI argument and the switch statement looks for the correct argument (`flow-legacy`) instead of the only one you can put on the CLI (`flow-leagcy`) 